### PR TITLE
Added a check for if a custom model has a name clash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Split out the electrolyzer cost models `basic` and `singlitico` for clarity.
 - Bump min Python version and removed unnecessary packages from `pyproject.toml.
 - Expanded docs to include a new section on modifying config dicts after model instantiation.
+- Added a check for if a custom model's name clashes with an existing model name in the H2Integrate framework, raising an error if it does.
 
 ## 0.3.0 [May 2 2025]
 

--- a/docs/user_guide/how_to_interface_with_user_defined_model.md
+++ b/docs/user_guide/how_to_interface_with_user_defined_model.md
@@ -43,7 +43,7 @@ You can combine an H2Integrate model and a custom model for the same technology 
 ## Getting started
 
 To use a custom model in your H2Integrate project, we recommend you look at existing models in the H2Integrate codebase to help guide the process.
-Then you can follow these steps:
+After learning the basic structure from those models, you can follow these steps:
 
 1. **Create configuration classes**
 
@@ -62,9 +62,13 @@ Then you can follow these steps:
    Treat your custom model as a drop-in component in your analysis workflow.
 
 ```{note}
-Custom models can include calls to external tools (e.g. an Excel macro) within the `compute` function as long as the required inputs and outputs are properly defined and handled.
+Your custom model cannot have the same name as an existing H2Integrate model. To remove ambiguity of which model would be used, an error will be raised if a custom model shares a name with an existing H2Integrate model.
 ```
 
 Refer to the [Paper Mill Model Example](https://github.com/NREL/H2Integrate/tree/develop/examples/06_custom_tech/) for a complete walkthrough.
 
 This feature supports broader adoption of H2I by allowing integration with the tools and models users already trust.
+
+```{note}
+Custom models can include calls to external tools (e.g. an Excel macro) within the `compute` function as long as the required inputs and outputs are properly defined and handled.
+```

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -84,7 +84,7 @@ class H2IntegrateModel:
             for model_type in ["performance_model", "cost_model", "financial_model"]:
                 if model_type in tech_config:
                     model_name = tech_config[model_type].get("model")
-                    if model_name not in self.supported_models and model_name is not None:
+                    if (model_name not in self.supported_models) and (model_name is not None):
                         model_class_name = tech_config[model_type].get("model_class_name")
                         model_location = tech_config[model_type].get("model_location")
 
@@ -110,6 +110,21 @@ class H2IntegrateModel:
 
                         # Add the custom model to the supported models dictionary
                         self.supported_models[model_name] = custom_model_class
+
+                    else:
+                        if (
+                            tech_config[model_type].get("model_class_name") is not None
+                            or tech_config[model_type].get("model_location") is not None
+                        ):
+                            msg = (
+                                f"Custom model_class_name or model_location "
+                                f"specified for '{model_name}', "
+                                f"but '{model_name}' is a built-in H2Integrate "
+                                "model. Using built-in model instead is not allowed. "
+                                f"If you want to use a custom model, please rename it "
+                                "in your configuration."
+                            )
+                            raise ValueError(msg)
 
     def create_site_model(self):
         site_group = om.Group()

--- a/h2integrate/core/test/test_framework.py
+++ b/h2integrate/core/test/test_framework.py
@@ -1,0 +1,64 @@
+import os
+import shutil
+from pathlib import Path
+
+import yaml
+import pytest
+
+from h2integrate.core.h2integrate_model import H2IntegrateModel
+from h2integrate.core.inputs.validation import load_tech_yaml
+
+
+examples_dir = Path(__file__).resolve().parent.parent.parent.parent / "examples/."
+
+
+def test_custom_model_name_clash(subtests):
+    # Change the current working directory to the example's directory
+    os.chdir(examples_dir / "01_onshore_steel_mn")
+
+    # Path to the original tech_config.yaml and high-level yaml in the example directory
+    orig_tech_config = Path.cwd() / "tech_config.yaml"
+    temp_tech_config = Path.cwd() / "temp_tech_config.yaml"
+    orig_highlevel_yaml = Path.cwd() / "01_onshore_steel_mn.yaml"
+    temp_highlevel_yaml = Path.cwd() / "temp_01_onshore_steel_mn.yaml"
+
+    # Copy the original tech_config.yaml and high-level yaml to temp files
+    shutil.copy(orig_tech_config, temp_tech_config)
+    shutil.copy(orig_highlevel_yaml, temp_highlevel_yaml)
+
+    # Load the tech_config YAML content
+    tech_config_data = load_tech_yaml(temp_tech_config)
+
+    tech_config_data["technologies"]["electrolyzer"]["cost_model"] = {
+        "model": "basic_electrolyzer_cost",
+        "model_location": "dummy_path",  # path doesn't matter; just that `model_location` exists
+    }
+
+    # Save the modified tech_config YAML back
+    with temp_tech_config.open("w") as f:
+        yaml.safe_dump(tech_config_data, f)
+
+    # Load the high-level YAML content
+    with temp_highlevel_yaml.open() as f:
+        highlevel_data = yaml.safe_load(f)
+
+    # Modify the high-level YAML to point to the temp tech_config file
+    highlevel_data["technology_config"] = str(temp_tech_config.name)
+
+    # Save the modified high-level YAML back
+    with temp_highlevel_yaml.open("w") as f:
+        yaml.safe_dump(highlevel_data, f)
+
+    # Assert that a ValueError is raised with the expected message when running the model
+    error_msg = (
+        r"Custom model_class_name or model_location specified for 'basic_electrolyzer_cost', "
+        r"but 'basic_electrolyzer_cost' is a built-in H2Integrate model\. "
+        r"Using built-in model instead is not allowed\. "
+        r"If you want to use a custom model, please rename it in your configuration\."
+    )
+    with pytest.raises(ValueError, match=error_msg):
+        H2IntegrateModel(temp_highlevel_yaml)
+
+    # Clean up temporary YAML files
+    temp_tech_config.unlink(missing_ok=True)
+    temp_highlevel_yaml.unlink(missing_ok=True)


### PR DESCRIPTION
# Added a check for if a custom model has a name clash

If a user attempts to create a custom model with the same name as a built-in H2I model, the framework will throw an error.
I made this is an error and not a warning to prevent users from running cases when there might be ambiguity in which model is being used -- it seems like a big enough deal to halt an analysis.

I'm open to suggestions if you think it should be a warning or logged instead of being an error!

## PR Checklist

<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
- [x] `CHANGELOG.md` has been updated to describe the changes made in this PR
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [x] Examples have been updated
- [x] Tests pass (If not, and this is expected, please elaborate in the tests section)
- [x] PR description thoroughly describes the new feature, bug fix, etc.

## Related issues

<!--If one exists, link to a related GitHub Issue.-->


## Impacted areas of the software

<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why.
-->

## Additional supporting information

<!--Add any other context about the problem here.-->


## Test results, if applicable

<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->


<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
