### PR TITLE
Sync open-loop controllers and corresponding storage models

### DIFF
--- a/docs/control/controller_demonstrations.md
+++ b/docs/control/controller_demonstrations.md
@@ -54,7 +54,7 @@ start_hour = 0
 end_hour = 200
 total_time_steps = model.prob.get_val("h2_storage.SOC").size
 demand_profile = [
-    model.technology_config["technologies"]["h2_storage"]["model_inputs"]["control_parameters"][
+    model.technology_config["technologies"]["h2_storage"]["model_inputs"]["shared_parameters"][
         "demand_profile"
     ]
     * 1e-3

--- a/docs/control/controller_demonstrations.md
+++ b/docs/control/controller_demonstrations.md
@@ -52,7 +52,7 @@ fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True, figsize=(8, 6), layout="tight"
 
 start_hour = 0
 end_hour = 200
-total_time_steps = model.prob.get_val("h2_storage.hydrogen_soc").size
+total_time_steps = model.prob.get_val("h2_storage.SOC").size
 demand_profile = [
     model.technology_config["technologies"]["h2_storage"]["model_inputs"]["control_parameters"][
         "demand_profile"
@@ -63,7 +63,7 @@ xvals = list(range(start_hour, end_hour))
 
 ax1.plot(
     xvals,
-    model.prob.get_val("h2_storage.hydrogen_soc", units="percent")[start_hour:end_hour],
+    model.prob.get_val("h2_storage.SOC", units="percent")[start_hour:end_hour],
     label="SOC",
 )
 ax2.plot(
@@ -74,13 +74,13 @@ ax2.plot(
 )
 ax2.plot(
     xvals,
-    model.prob.get_val("h2_storage.hydrogen_unused_commodity", units="t/h")[start_hour:end_hour],
+    model.prob.get_val("h2_storage.unused_hydrogen_out", units="t/h")[start_hour:end_hour],
     linestyle=":",
     label="H$_2$ Unused (kg)",
 )
 ax2.plot(
     xvals,
-    model.prob.get_val("h2_storage.hydrogen_unmet_demand", units="t/h")[start_hour:end_hour],
+    model.prob.get_val("h2_storage.unmet_hydrogen_demand_out", units="t/h")[start_hour:end_hour],
     linestyle=":",
     label="H$_2$ Unmet Demand (kg)",
 )

--- a/examples/03_methanol/co2_hydrogenation_doc/tech_config_co2h.yaml
+++ b/examples/03_methanol/co2_hydrogenation_doc/tech_config_co2h.yaml
@@ -85,15 +85,15 @@ technologies:
         commodity_rate_units: kg/h
         max_charge_rate: 50000.0  # kg/time step
         max_capacity: 103701.401563086  # kg
-      control_parameters:
         max_charge_fraction: 1.0  # fraction (0-1)
         min_charge_fraction: 0.1  # fraction (0-1)
         init_charge_fraction: 0.25  # fraction (0-1)
-        max_discharge_rate: 5000.0  # kg/time step
-        charge_equals_discharge: false
         charge_efficiency: 1.0  # fraction (0-1)
         discharge_efficiency: 1.0  # fraction (0-1)
         demand_profile: 2108.73919484047
+      control_parameters:
+        max_discharge_rate: 5000.0  # kg/time step
+        charge_equals_discharge: false
       cost_parameters:
         cost_year: 2022
         capacity_capex: 383  # $/kg - based on https://www.hydrogen.energy.gov/docs/hydrogenprogramlibraries/pdfs/review22/st235_houchins_2022_p-pdf.pdf?Status=Master
@@ -141,14 +141,14 @@ technologies:
         commodity_rate_units: kg/h
         max_charge_rate: 50000.0  # kg/time step
         max_capacity: 961456.376748904  # kg
-      control_parameters:
         max_charge_fraction: 1.0  # fraction (0-1)
         min_charge_fraction: 0.1  # fraction (0-1)
         init_charge_fraction: 0.25  # fraction (0-1)
-        max_discharge_rate: 50000.0  # kg/time step
         charge_efficiency: 1.0  # fraction (0-1)
         discharge_efficiency: 1.0  # fraction (0-1)
         demand_profile: 15388.3891
+      control_parameters:
+        max_discharge_rate: 50000.0  # kg/time step
       cost_parameters:
         cost_year: 2022
         capacity_capex: 5  # $/kg - based on https://www.maritime.dot.gov/sites/marad.dot.gov/files/2024-11/LCE%20MARAD%20CCS%20TEA%20Final%20Report%20-%2031%20May%202024%20%283%29.pdf

--- a/examples/14_wind_hydrogen_dispatch/inputs/tech_config.yaml
+++ b/examples/14_wind_hydrogen_dispatch/inputs/tech_config.yaml
@@ -62,11 +62,11 @@ technologies:
         commodity_rate_units: kg/h
         max_charge_rate: 12446.00729773  # kg/time step
         max_capacity: 2987042.0  # kg
-      control_parameters:
         max_charge_fraction: 1.0  # fraction (0-1)
         min_charge_fraction: 0.1  # fraction (0-1)
         init_charge_fraction: 0.25  # fraction (0-1)
-        max_discharge_rate: 12446.00729773  # kg/time step
         charge_efficiency: 1.0  # fraction (0-1)
         discharge_efficiency: 1.0  # fraction (0-1)
         demand_profile: 5000  # constant demand of 5000 kg per hour (see commodity_rate_units)
+      control_parameters:
+        max_discharge_rate: 12446.00729773  # kg/time step

--- a/examples/16_natural_gas/plant_config.yaml
+++ b/examples/16_natural_gas/plant_config.yaml
@@ -22,7 +22,7 @@ technology_interconnections:
                                                   # connect solar to battery
   - [ng_feedstock, natural_gas_plant, natural_gas, pipe]
                                                                   # connect NG feedstock to NG plant
-  - [battery, natural_gas_plant, [electricity_unmet_demand, electricity_demand]]
+  - [battery, natural_gas_plant, [unmet_electricity_demand_out, electricity_demand]]
                                                                                          # connect electricity demand to NG feedstock
     # connect natural gas and battery to combiner
   - [solar, fin_combiner, electricity, cable]

--- a/examples/16_natural_gas/tech_config.yaml
+++ b/examples/16_natural_gas/tech_config.yaml
@@ -42,14 +42,14 @@ technologies:
         commodity_rate_units: kW
         max_charge_rate: 25000.0  # kW/time step, 25 MW
         max_capacity: 200000.0  # kWh, 200 MWh
-      control_parameters:
         max_charge_fraction: 1.0  # fraction (0-1)
         min_charge_fraction: 0.1  # fraction (0-1)
         init_charge_fraction: 0.1  # fraction (0-1)
-        max_discharge_rate: 25000.0  # kW/time step
         charge_efficiency: 1.0  # fraction (0-1)
         discharge_efficiency: 1.0  # fraction (0-1)
         demand_profile: 100000  # kW, 100 MW
+      control_parameters:
+        max_discharge_rate: 25000.0  # kW/time step
       cost_parameters:
         cost_year: 2022
         energy_capex: 300  # $/kWh

--- a/examples/19_simple_dispatch/tech_config.yaml
+++ b/examples/19_simple_dispatch/tech_config.yaml
@@ -41,14 +41,14 @@ technologies:
         commodity_rate_units: kW
         max_charge_rate: 5000.0  # kW
         max_capacity: 30000.0  # kWh
-      control_parameters:
         max_charge_fraction: 1.0  # fraction (0-1)
         min_charge_fraction: 0.1  # fraction (0-1)
         init_charge_fraction: 0.25  # fraction (0-1)
-        max_discharge_rate: 5000.0  # kW
         charge_efficiency: 1.0  # fraction (0-1)
         discharge_efficiency: 1.0  # fraction (0-1)
         demand_profile: 5000  # kW
+      control_parameters:
+        max_discharge_rate: 5000.0  # kW
       cost_parameters:
         cost_year: 2022
         energy_capex: 300  # $/kWh

--- a/examples/24_solar_battery_grid/plant_config.yaml
+++ b/examples/24_solar_battery_grid/plant_config.yaml
@@ -21,9 +21,9 @@ sites:
 technology_interconnections:
   - [solar, battery, electricity, cable]
                                                   # connect solar to battery
-  - [battery, grid_buy, [electricity_unmet_demand, electricity_demand]]
+  - [battery, grid_buy, [unmet_electricity_demand_out, electricity_demand]]
                                                                                  # connect battery demand to grid buying
-  - [battery, grid_sell, [electricity_unused_commodity, electricity_in]]
+  - [battery, grid_sell, [unused_electricity_out, electricity_in]]
                                                                                   # connect battery surplus to grid selling
   - [solar, combiner, electricity, cable]
   - [grid_buy, combiner, electricity, cable]

--- a/examples/24_solar_battery_grid/tech_config.yaml
+++ b/examples/24_solar_battery_grid/tech_config.yaml
@@ -42,14 +42,14 @@ technologies:
         commodity_rate_units: kW
         max_charge_rate: 25000.0  # kW/time step, 25 MW
         max_capacity: 200000.0  # kWh, 200 MWh
-      control_parameters:
         max_charge_fraction: 1.0  # fraction (0-1)
         min_charge_fraction: 0.1  # fraction (0-1)
         init_charge_fraction: 0.1  # fraction (0-1)
-        max_discharge_rate: 25000.0  # kW/time step
         charge_efficiency: 1.0  # fraction (0-1)
         discharge_efficiency: 1.0  # fraction (0-1)
         demand_profile: 100000  # kW, 100 MW
+      control_parameters:
+        max_discharge_rate: 25000.0  # kW/time step
       cost_parameters:
         cost_year: 2022
         energy_capex: 300  # $/kWh

--- a/examples/29_wind_ard/h2i_inputs/tech_config.yaml
+++ b/examples/29_wind_ard/h2i_inputs/tech_config.yaml
@@ -107,14 +107,14 @@ technologies:
         commodity_rate_units: kW
         max_charge_rate: 95000.0  # kW/time step
         max_capacity: 190000.0  # kWh
-      control_parameters:
         max_charge_fraction: 1.0  # fraction (0-1)
         min_charge_fraction: 0.1  # fraction (0-1)
         init_charge_fraction: 0.25  # fraction (0-1)
-        max_discharge_rate: 95000.0  # kW/time step
         charge_efficiency: 0.985  # fraction (0-1)
         discharge_efficiency: 0.985  # fraction (0-1)
         demand_profile: 30000
+      control_parameters:
+        max_discharge_rate: 95000.0  # kW/time step
       cost_parameters:
         cost_year: 2022
         energy_capex: 72.54  # $/kWh

--- a/examples/test/test_all_examples.py
+++ b/examples/test/test_all_examples.py
@@ -919,12 +919,9 @@ def test_natural_gas_example(subtests, temp_copy_of_example):
 
     model.run()
 
-    model.post_process()
     solar_aep = sum(model.prob.get_val("solar.electricity_out", units="kW"))
     solar_bat_out_total = sum(model.prob.get_val("battery.electricity_out", units="kW"))
-    solar_curtailed_total = sum(
-        model.prob.get_val("battery.electricity_unused_commodity", units="kW")
-    )
+    solar_curtailed_total = sum(model.prob.get_val("battery.unused_electricity_out", units="kW"))
 
     renewable_subgroup_total_electricity = (
         model.prob.get_val("finance_subgroup_renewables.rated_electricity_production", units="kW")[
@@ -954,7 +951,7 @@ def test_natural_gas_example(subtests, temp_copy_of_example):
 
     # NOTE: battery output power is not included in any of the financials
 
-    pre_ng_missed_load = model.prob.get_val("battery.electricity_unmet_demand", units="kW")
+    pre_ng_missed_load = model.prob.get_val("battery.unmet_electricity_demand_out", units="kW")
     ng_electricity_demand = model.prob.get_val("natural_gas_plant.electricity_demand", units="kW")
     ng_electricity_production = model.prob.get_val("natural_gas_plant.electricity_out", units="kW")
     bat_init_charge = 200000.0 * 0.1  # max capacity in kW and initial charge rate percentage

--- a/examples/test/test_all_examples.py
+++ b/examples/test/test_all_examples.py
@@ -1319,7 +1319,7 @@ def test_simple_dispatch_example(subtests, temp_copy_of_example):
 
     # Test battery storage functionality
     with subtests.test("Check battery SOC bounds"):
-        soc = model.prob.get_val("battery.electricity_soc", units="unitless")
+        soc = model.prob.get_val("battery.SOC", units="unitless")
         # SOC should stay within configured bounds (10% to 100%)
         assert all(soc >= 0.1)
         assert all(soc <= 1.0)
@@ -1374,14 +1374,14 @@ def test_simple_dispatch_example(subtests, temp_copy_of_example):
     # Subtest for electricity unused_commodity
     with subtests.test("Check electricity unused commodity"):
         electricity_unused_commodity = np.linalg.norm(
-            model.prob.get_val("battery.electricity_unused_commodity", units="kW")
+            model.prob.get_val("battery.unused_electricity_out", units="kW")
         )
         assert pytest.approx(electricity_unused_commodity, rel=1e-6) == 412531.73840450746
 
     # Subtest for unmet demand
     with subtests.test("Check electricity unmet demand"):
         electricity_unmet_demand = np.linalg.norm(
-            model.prob.get_val("battery.electricity_unmet_demand", units="kW")
+            model.prob.get_val("battery.unmet_electricity_demand_out", units="kW")
         )
         assert pytest.approx(electricity_unmet_demand, rel=1e-6) == 165604.70758669
 
@@ -1526,7 +1526,7 @@ def test_windard_pv_battery_dispatch_example(subtests, temp_copy_of_example):
     # Subtest for missed load
     with subtests.test("Check electricity missed load"):
         electricity_missed_load = np.linalg.norm(
-            model.prob.get_val("battery.electricity_unmet_demand", units="MW")
+            model.prob.get_val("battery.unmet_electricity_demand_out", units="MW")
         )
         assert electricity_missed_load == pytest.approx(1403.5372787817894)
 
@@ -1909,9 +1909,11 @@ def test_24_solar_battery_grid_example(subtests, temp_copy_of_example):
     )
 
     electricity_bought = sum(model.prob.get_val("grid_buy.electricity_out", units="kW"))
-    battery_missed_load = sum(model.prob.get_val("battery.electricity_unmet_demand", units="kW"))
+    battery_missed_load = sum(
+        model.prob.get_val("battery.unmet_electricity_demand_out", units="kW")
+    )
 
-    battery_curtailed = sum(model.prob.get_val("battery.electricity_unused_commodity", units="kW"))
+    battery_curtailed = sum(model.prob.get_val("battery.unused_electricity_out", units="kW"))
     electricity_sold = sum(model.prob.get_val("grid_sell.electricity_in", units="kW"))
 
     solar_aep = sum(model.prob.get_val("solar.electricity_out", units="kW"))

--- a/examples/test/test_all_examples.py
+++ b/examples/test/test_all_examples.py
@@ -1517,7 +1517,7 @@ def test_windard_pv_battery_dispatch_example(subtests, temp_copy_of_example):
     # Subtest for electricity curtailed
     with subtests.test("Check electricity curtailed"):
         electricity_curtailed = model.prob.get_val(
-            "battery.electricity_unused_commodity", units="MW"
+            "battery.unused_electricity_out", units="MW"
         ).sum()
 
         # import pdb; pdb.set_trace()

--- a/h2integrate/control/control_strategies/passthrough_openloop_controller.py
+++ b/h2integrate/control/control_strategies/passthrough_openloop_controller.py
@@ -37,11 +37,22 @@ class PassThroughOpenLoopController(om.ExplicitComponent):
             additional_cls_name=self.__class__.__name__,
         )
 
+        n_timesteps = int(self.options["plant_config"]["plant"]["simulation"]["n_timesteps"])
+
         self.add_input(
             f"{self.config.commodity}_in",
-            shape_by_conn=True,
+            val=0.0,
+            shape=n_timesteps,
             units=self.config.commodity_rate_units,
             desc=f"{self.config.commodity} input timeseries from production to storage",
+        )
+
+        self.add_input(
+            f"{self.config.commodity}_demand",
+            val=0.0,
+            shape=n_timesteps,
+            units=self.config.commodity_rate_units,
+            desc=f"{self.config.commodity} demand",
         )
 
         self.add_output(
@@ -63,7 +74,9 @@ class PassThroughOpenLoopController(om.ExplicitComponent):
         """
 
         # Assign the input to the output
-        outputs[f"{self.config.commodity}_set_point"] = inputs[f"{self.config.commodity}_in"]
+        outputs[f"{self.config.commodity}_set_point"] = (
+            inputs[f"{self.config.commodity}_demand"] - inputs[f"{self.config.commodity}_in"]
+        )
 
     def setup_partials(self):
         """

--- a/h2integrate/control/control_strategies/passthrough_openloop_controller.py
+++ b/h2integrate/control/control_strategies/passthrough_openloop_controller.py
@@ -9,6 +9,7 @@ from h2integrate.core.utilities import BaseConfig, merge_shared_inputs
 class PassThroughOpenLoopControllerConfig(BaseConfig):
     commodity: str = field()
     commodity_rate_units: str = field()
+    demand_profile: int | float | list = field(default=0.0)
 
 
 class PassThroughOpenLoopController(om.ExplicitComponent):
@@ -49,7 +50,7 @@ class PassThroughOpenLoopController(om.ExplicitComponent):
 
         self.add_input(
             f"{self.config.commodity}_demand",
-            val=0.0,
+            val=self.config.demand_profile,
             shape=n_timesteps,
             units=self.config.commodity_rate_units,
             desc=f"{self.config.commodity} demand",
@@ -73,9 +74,18 @@ class PassThroughOpenLoopController(om.ExplicitComponent):
                 - {commodity}_out: Output commodity flow, equal to the input flow.
         """
 
+        if np.sum(inputs[f"{self.config.commodity}_demand"]) > 0:
+            commodity_demand = inputs[f"{self.config.commodity}_demand"]
+        else:
+            # If the commodity_demand is zero, use the average
+            # commodity_in as the demand
+            commodity_demand = np.mean(inputs[f"{self.config.commodity}_in"]) * np.ones(
+                len(inputs[f"{self.config.commodity}_demand"])
+            )
+
         # Assign the input to the output
         outputs[f"{self.config.commodity}_set_point"] = (
-            inputs[f"{self.config.commodity}_demand"] - inputs[f"{self.config.commodity}_in"]
+            commodity_demand - inputs[f"{self.config.commodity}_in"]
         )
 
     def setup_partials(self):

--- a/h2integrate/control/control_strategies/passthrough_openloop_controller.py
+++ b/h2integrate/control/control_strategies/passthrough_openloop_controller.py
@@ -87,29 +87,3 @@ class PassThroughOpenLoopController(om.ExplicitComponent):
         outputs[f"{self.config.commodity}_set_point"] = (
             commodity_demand - inputs[f"{self.config.commodity}_in"]
         )
-
-    def setup_partials(self):
-        """
-        Declare partial derivatives as unity throughout the design space.
-
-        This method specifies that the derivative of the output with respect to the input is
-        always 1.0, consistent with the pass-through behavior.
-
-        Note:
-        This method is not currently used and isn't strictly needed if you're creating other
-        controllers; it is included as a nod towards potential future development enabling
-        more derivative information passing.
-        """
-
-        # Get the size of the input/output array
-        size = self._get_var_meta(f"{self.config.commodity}_in", "size")
-
-        # Declare partials sparsely for all elements as an identity matrix
-        # (diagonal elements are 1.0, others are 0.0)
-        self.declare_partials(
-            of=f"{self.config.commodity}_set_point",
-            wrt=f"{self.config.commodity}_in",
-            rows=np.arange(size),
-            cols=np.arange(size),
-            val=np.ones(size),  # Diagonal elements are 1.0
-        )

--- a/h2integrate/control/control_strategies/storage/demand_openloop_controller.py
+++ b/h2integrate/control/control_strategies/storage/demand_openloop_controller.py
@@ -308,17 +308,27 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
             )
             raise UserWarning(msg)
 
-        max_capacity = inputs["max_capacity"].item()
-        max_charge_fraction = self.config.max_charge_fraction
-        min_charge_fraction = self.config.min_charge_fraction
+        # Pre-compute scalar constants to avoid repeated attribute lookups
+        # and redundant divisions inside the per-timestep loop.
+        charge_eff = float(self.config.charge_efficiency)
+        discharge_eff = float(self.config.discharge_efficiency)
+        soc_max = self.config.max_charge_fraction
+        soc_min = self.config.min_charge_fraction
+
         init_charge_fraction = self.config.init_charge_fraction
-        max_charge_rate = inputs["max_charge_rate"].item()
+        charge_rate = inputs["max_charge_rate"].item()
         if self.config.charge_equals_discharge:
-            max_discharge_rate = inputs["max_charge_rate"].item()
+            discharge_rate = inputs["max_charge_rate"].item()
         else:
-            max_discharge_rate = inputs["max_discharge_rate"].item()
-        charge_efficiency = float(self.config.charge_efficiency)
-        discharge_efficiency = float(self.config.discharge_efficiency)
+            discharge_rate = inputs["max_discharge_rate"].item()
+
+        # max_charge_input / max_discharge_input are the hardware rate limits
+        # expressed in *pre-efficiency* rate units so they can be compared
+        # directly against the SOC headroom and the raw command magnitude.
+        # max_charge_input = charge_rate / charge_eff
+        # max_discharge_input = discharge_rate / discharge_eff
+
+        max_capacity = inputs["max_capacity"].item()
 
         # Initialize time-step state of charge prior to loop so the loop starts with
         # the previous time step's value
@@ -327,10 +337,7 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
         demand_profile = inputs[f"{commodity}_demand"]
 
         # initialize outputs
-        np.zeros(self.n_timesteps)
-        np.zeros(self.n_timesteps)
         output_array = np.zeros(self.n_timesteps)
-        np.zeros(self.n_timesteps)
         total_output_array = np.zeros(self.n_timesteps)
 
         # Loop through each time step
@@ -339,8 +346,8 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
             input_flow = inputs[f"{commodity}_in"][t]
 
             # Calculate the available charge/discharge capacity
-            available_charge = float((max_charge_fraction - soc) * max_capacity)
-            available_discharge = float((soc - min_charge_fraction) * max_capacity)
+            available_charge = float((soc_max - soc) * max_capacity)
+            available_discharge = float((soc - soc_min) * max_capacity)
 
             # Initialize persistent variables for curtailment and missed load
             unused_input = 0.0
@@ -350,22 +357,22 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
             if demand_t > input_flow:
                 # Discharge storage to meet demand.
                 # `discharge_needed` is as seen by the storage
-                discharge_needed = (demand_t - input_flow) / discharge_efficiency
+                discharge_needed = (demand_t - input_flow) / discharge_eff
                 # `discharge` is as seen by the storage, but `max_discharge_rate` is as observed
                 # outside the storage
                 discharge = (
                     min(
                         discharge_needed,
                         available_discharge,
-                        max_discharge_rate / discharge_efficiency,
+                        discharge_rate / discharge_eff,
                     )
-                    * discharge_efficiency
+                    * discharge_eff
                 )
 
                 soc -= discharge / max_capacity  # soc is a ratio with value between 0 and 1
                 # output is as observed outside the storage, so we need to adjust `discharge` by
                 # applying `discharge_efficiency`.
-                total_output_array[t] = input_flow + discharge * discharge_efficiency
+                total_output_array[t] = input_flow + discharge
                 output_array[t] = discharge
             else:
                 # Charge storage with unused input
@@ -375,10 +382,7 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
                 # `charge` is as seen by the storage, but the things being compared should all be as
                 # seen outside the storage so we need to adjust `available_charge` outside the
                 # storage view and the final result back into the storage view.
-                charge = (
-                    min(unused_input, available_charge / charge_efficiency, max_charge_rate)
-                    * charge_efficiency
-                )
+                charge = min(unused_input, available_charge / charge_eff, charge_rate) * charge_eff
 
                 output_array[t] = -1 * charge
                 total_output_array[t] = demand_t
@@ -386,7 +390,7 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
                 soc += charge / max_capacity  # soc is a ratio with value between 0 and 1
 
             # Ensure SOC stays within bounds
-            soc = max(min_charge_fraction, min(max_charge_fraction, soc))
+            soc = max(soc_min, min(soc_max, soc))
 
             # Record the SOC for the current time step
             # soc_array[t] = deepcopy(soc)

--- a/h2integrate/control/control_strategies/storage/demand_openloop_controller.py
+++ b/h2integrate/control/control_strategies/storage/demand_openloop_controller.py
@@ -366,7 +366,7 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
                 # output is as observed outside the storage, so we need to adjust `discharge` by
                 # applying `discharge_efficiency`.
                 total_output_array[t] = input_flow + discharge * discharge_efficiency
-                output_array[t] = discharge * discharge_efficiency
+                output_array[t] = discharge
             else:
                 # Charge storage with unused input
                 # `unused_input` is as seen outside the storage
@@ -380,7 +380,7 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
                     * charge_efficiency
                 )
 
-                output_array[t] = -1 * charge * charge_efficiency
+                output_array[t] = -1 * charge
                 total_output_array[t] = demand_t
 
                 soc += charge / max_capacity  # soc is a ratio with value between 0 and 1

--- a/h2integrate/control/control_strategies/storage/demand_openloop_controller.py
+++ b/h2integrate/control/control_strategies/storage/demand_openloop_controller.py
@@ -1,24 +1,27 @@
 from copy import deepcopy
 
 import numpy as np
+import openmdao.api as om
 from attrs import field, define
 
-from h2integrate.core.utilities import merge_shared_inputs
+from h2integrate.core.utilities import BaseConfig, merge_shared_inputs
 from h2integrate.core.validators import gte_zero, range_val, range_val_or_none
-from h2integrate.control.control_strategies.demand_openloop_controller import (
-    DemandOpenLoopControlBase,
-    DemandOpenLoopControlBaseConfig,
-)
 
 
 @define(kw_only=True)
-class DemandOpenLoopStorageControllerConfig(DemandOpenLoopControlBaseConfig):
+class DemandOpenLoopStorageControllerConfig(BaseConfig):
     """
     Configuration class for the DemandOpenLoopStorageController.
 
     This class defines the parameters required to configure the `DemandOpenLoopStorageController`.
 
     Attributes:
+        commodity_rate_units (str): Units of the commodity (e.g., "kg/h").
+        commodity (str): Name of the commodity being controlled
+            (e.g., "hydrogen"). Converted to lowercase and stripped of whitespace.
+        demand_profile (int | float | list): Demand values for each timestep, in
+            the same units as `commodity_rate_units`. May be a scalar for constant
+            demand or a list/array for time-varying demand.
         max_capacity (float): Maximum storage capacity of the commodity (in non-rate units,
             e.g., "kg" if `commodity_rate_units` is "kg/h").
         max_charge_fraction (float): Maximum allowable state of charge (SOC) as a fraction
@@ -47,6 +50,10 @@ class DemandOpenLoopStorageControllerConfig(DemandOpenLoopControlBaseConfig):
             provided.
     """
 
+    commodity_rate_units: str = field(converter=str.strip)
+    commodity: str = field(converter=(str.strip, str.lower))
+    demand_profile: int | float | list = field()
+
     max_capacity: float = field()
     max_charge_fraction: float = field(validator=range_val(0, 1))
     min_charge_fraction: float = field(validator=range_val(0, 1))
@@ -57,6 +64,7 @@ class DemandOpenLoopStorageControllerConfig(DemandOpenLoopControlBaseConfig):
     charge_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
     discharge_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
     round_trip_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
+    commodity_amount_units: str = field(default=None)
 
     def __attrs_post_init__(self):
         """
@@ -70,8 +78,9 @@ class DemandOpenLoopStorageControllerConfig(DemandOpenLoopControlBaseConfig):
         if self.round_trip_efficiency is not None:
             if self.charge_efficiency is not None or self.discharge_efficiency is not None:
                 raise ValueError(
-                    "Provide either `round_trip_efficiency` or both `charge_efficiency` "
-                    "and `discharge_efficiency`, but not both."
+                    "Exactly one of the following sets of parameters must be set: (a) "
+                    "`round_trip_efficiency`, or (b) both `charge_efficiency` "
+                    "and `discharge_efficiency`."
                 )
             # Calculate charge and discharge efficiencies from round-trip efficiency
             self.charge_efficiency = np.sqrt(self.round_trip_efficiency)
@@ -81,8 +90,9 @@ class DemandOpenLoopStorageControllerConfig(DemandOpenLoopControlBaseConfig):
             pass
         else:
             raise ValueError(
-                "You must provide either `round_trip_efficiency` or both "
-                "`charge_efficiency` and `discharge_efficiency`."
+                "Exactly one of the following sets of parameters must be set: (a) "
+                "`round_trip_efficiency`, or (b) both `charge_efficiency` "
+                "and `discharge_efficiency`."
             )
 
         if self.charge_equals_discharge:
@@ -98,9 +108,11 @@ class DemandOpenLoopStorageControllerConfig(DemandOpenLoopControlBaseConfig):
                 raise ValueError(msg)
 
             self.max_discharge_rate = self.max_charge_rate
+        if self.commodity_amount_units is None:
+            self.commodity_amount_units = f"({self.commodity_rate_units})*h"
 
 
-class DemandOpenLoopStorageController(DemandOpenLoopControlBase):
+class DemandOpenLoopStorageController(om.ExplicitComponent):
     """
     A controller that manages commodity flow based on demand and storage constraints.
 
@@ -142,6 +154,21 @@ class DemandOpenLoopStorageController(DemandOpenLoopControlBase):
             - Units: Defined in `commodity_rate_units` (e.g., "kg").
     """
 
+    def initialize(self):
+        """Declare component options.
+
+        Options:
+            driver_config (dict): Driver-level configuration parameters.
+            plant_config (dict): Plant-level configuration, including number of
+                simulation timesteps.
+            tech_config (dict): Technology-specific configuration, including
+                controller settings.
+
+        """
+        self.options.declare("driver_config", types=dict)
+        self.options.declare("plant_config", types=dict)
+        self.options.declare("tech_config", types=dict)
+
     def setup(self):
         """
         Set up inputs, outputs, and configuration for the open-loop storage controller.
@@ -176,6 +203,22 @@ class DemandOpenLoopStorageController(DemandOpenLoopControlBase):
         commodity = self.config.commodity
 
         self.add_input(
+            f"{commodity}_demand",
+            val=self.config.demand_profile,
+            shape=self.n_timesteps,
+            units=self.config.commodity_rate_units,
+            desc=f"Demand profile of {commodity}",
+        )
+
+        self.add_input(
+            f"{commodity}_in",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.config.commodity_rate_units,
+            desc=f"Amount of {commodity} demand that has already been supplied",
+        )
+
+        self.add_input(
             "max_charge_rate",
             val=self.config.max_charge_rate,
             units=self.config.commodity_rate_units,
@@ -189,18 +232,34 @@ class DemandOpenLoopStorageController(DemandOpenLoopControlBase):
             desc="Maximum storage capacity",
         )
 
-        self.add_output(
-            f"{commodity}_soc",
-            copy_shape=f"{commodity}_in",
-            units="unitless",
-            desc=f"{commodity} state of charge timeseries for storage",
-        )
+        if not self.config.charge_equals_discharge:
+            self.add_input(
+                "max_discharge_rate",
+                val=self.config.max_discharge_rate,
+                units=self.config.commodity_rate_units,
+                desc="Storage discharge rate",
+            )
 
         self.add_output(
-            "storage_duration",
-            units="h",
-            desc="Estimated storage duration based on max capacity and discharge rate",
+            f"{commodity}_set_point",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.config.commodity_rate_units,
+            desc=f"Production profile of {commodity}",
         )
+
+        # self.add_output(
+        #     f"{commodity}_soc",
+        #     copy_shape=f"{commodity}_in",
+        #     units="unitless",
+        #     desc=f"{commodity} state of charge timeseries for storage",
+        # )
+
+        # self.add_output(
+        #     "storage_duration",
+        #     units="h",
+        #     desc="Estimated storage duration based on max capacity and discharge rate",
+        # )
 
     def compute(self, inputs, outputs):
         """
@@ -266,7 +325,7 @@ class DemandOpenLoopStorageController(DemandOpenLoopControlBase):
         if self.config.charge_equals_discharge:
             max_discharge_rate = inputs["max_charge_rate"].item()
         else:
-            max_discharge_rate = float(self.config.max_discharge_rate)
+            max_discharge_rate = inputs["max_discharge_rate"].item()
         charge_efficiency = float(self.config.charge_efficiency)
         discharge_efficiency = float(self.config.discharge_efficiency)
 
@@ -277,11 +336,11 @@ class DemandOpenLoopStorageController(DemandOpenLoopControlBase):
         demand_profile = inputs[f"{commodity}_demand"]
 
         # initialize outputs
-        soc_array = outputs[f"{commodity}_soc"]
-        unused_commodity_array = outputs[f"{commodity}_unused_commodity"]
-        output_array = outputs[f"{commodity}_set_point"]
-        unmet_demand_array = outputs[f"{commodity}_unmet_demand"]
-        total_output_array = np.zeros(len(output_array))
+        soc_array = np.zeros(self.n_timesteps)
+        unused_commodity_array = np.zeros(self.n_timesteps)
+        output_array = np.zeros(self.n_timesteps)
+        unmet_demand_array = np.zeros(self.n_timesteps)
+        total_output_array = np.zeros(self.n_timesteps)
 
         # Loop through each time step
         for t, demand_t in enumerate(demand_profile):
@@ -343,17 +402,17 @@ class DemandOpenLoopStorageController(DemandOpenLoopControlBase):
 
         outputs[f"{commodity}_set_point"] = output_array
 
-        # Return the SOC
-        outputs[f"{commodity}_soc"] = soc_array
+        # # Return the SOC
+        # outputs[f"{commodity}_soc"] = soc_array
 
-        # Return the unused commodity
-        outputs[f"{commodity}_unused_commodity"] = unused_commodity_array
+        # # Return the unused commodity
+        # outputs[f"{commodity}_unused_commodity"] = unused_commodity_array
 
-        # Return the unmet load demand
-        outputs[f"{commodity}_unmet_demand"] = unmet_demand_array
+        # # Return the unmet load demand
+        # outputs[f"{commodity}_unmet_demand"] = unmet_demand_array
 
-        # Calculate and return the total unmet demand over the simulation period
-        outputs[f"total_{commodity}_unmet_demand"] = np.sum(unmet_demand_array)
+        # # Calculate and return the total unmet demand over the simulation period
+        # outputs[f"total_{commodity}_unmet_demand"] = np.sum(unmet_demand_array)
 
-        # Output the storage duration in hours
-        outputs["storage_duration"] = max_capacity / max_discharge_rate
+        # # Output the storage duration in hours
+        # outputs["storage_duration"] = max_capacity / max_discharge_rate

--- a/h2integrate/control/control_strategies/storage/demand_openloop_controller.py
+++ b/h2integrate/control/control_strategies/storage/demand_openloop_controller.py
@@ -230,9 +230,9 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
         )
 
         self.add_input(
-            "max_capacity",
+            "max_capacity",  # TODO: rename to storage_capacity
             val=self.config.max_capacity,
-            units=self.config.commodity_rate_units + "*h",
+            units=self.config.commodity_rate_units + "*h",  # TODO: update to commodity_amount_units
             desc="Maximum storage capacity",
         )
 
@@ -330,8 +330,8 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
 
         max_capacity = inputs["max_capacity"].item()
 
-        # Initialize time-step state of charge prior to loop so the loop starts with
-        # the previous time step's value
+        # Initialize time-step state of charge prior to loop so the loop starts
+        # with the initial SOC
         soc = deepcopy(init_charge_fraction)
 
         demand_profile = inputs[f"{commodity}_demand"]

--- a/h2integrate/control/control_strategies/storage/demand_openloop_controller.py
+++ b/h2integrate/control/control_strategies/storage/demand_openloop_controller.py
@@ -50,20 +50,24 @@ class DemandOpenLoopStorageControllerConfig(BaseConfig):
             provided.
     """
 
-    commodity_rate_units: str = field(converter=str.strip)
     commodity: str = field(converter=(str.strip, str.lower))
+    commodity_rate_units: str = field(converter=str.strip)
+
     demand_profile: int | float | list = field()
 
     max_capacity: float = field()
     max_charge_fraction: float = field(validator=range_val(0, 1))
     min_charge_fraction: float = field(validator=range_val(0, 1))
     init_charge_fraction: float = field(validator=range_val(0, 1))
+
     max_charge_rate: float = field(validator=gte_zero)
     charge_equals_discharge: bool = field(default=True)
     max_discharge_rate: float | None = field(default=None)
+
     charge_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
     discharge_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
     round_trip_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
+
     commodity_amount_units: str = field(default=None)
 
     def __attrs_post_init__(self):
@@ -248,19 +252,6 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
             desc=f"Production profile of {commodity}",
         )
 
-        # self.add_output(
-        #     f"{commodity}_soc",
-        #     copy_shape=f"{commodity}_in",
-        #     units="unitless",
-        #     desc=f"{commodity} state of charge timeseries for storage",
-        # )
-
-        # self.add_output(
-        #     "storage_duration",
-        #     units="h",
-        #     desc="Estimated storage duration based on max capacity and discharge rate",
-        # )
-
     def compute(self, inputs, outputs):
         """
         Compute storage state of charge (SOC), delivered output, curtailment, and unmet
@@ -336,10 +327,10 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
         demand_profile = inputs[f"{commodity}_demand"]
 
         # initialize outputs
-        soc_array = np.zeros(self.n_timesteps)
-        unused_commodity_array = np.zeros(self.n_timesteps)
+        np.zeros(self.n_timesteps)
+        np.zeros(self.n_timesteps)
         output_array = np.zeros(self.n_timesteps)
-        unmet_demand_array = np.zeros(self.n_timesteps)
+        np.zeros(self.n_timesteps)
         total_output_array = np.zeros(self.n_timesteps)
 
         # Loop through each time step
@@ -362,8 +353,13 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
                 discharge_needed = (demand_t - input_flow) / discharge_efficiency
                 # `discharge` is as seen by the storage, but `max_discharge_rate` is as observed
                 # outside the storage
-                discharge = min(
-                    discharge_needed, available_discharge, max_discharge_rate / discharge_efficiency
+                discharge = (
+                    min(
+                        discharge_needed,
+                        available_discharge,
+                        max_discharge_rate / discharge_efficiency,
+                    )
+                    * discharge_efficiency
                 )
 
                 soc -= discharge / max_capacity  # soc is a ratio with value between 0 and 1
@@ -383,36 +379,23 @@ class DemandOpenLoopStorageController(om.ExplicitComponent):
                     min(unused_input, available_charge / charge_efficiency, max_charge_rate)
                     * charge_efficiency
                 )
-                soc += charge / max_capacity  # soc is a ratio with value between 0 and 1
+
                 output_array[t] = -1 * charge * charge_efficiency
                 total_output_array[t] = demand_t
+
+                soc += charge / max_capacity  # soc is a ratio with value between 0 and 1
 
             # Ensure SOC stays within bounds
             soc = max(min_charge_fraction, min(max_charge_fraction, soc))
 
             # Record the SOC for the current time step
-            soc_array[t] = deepcopy(soc)
+            # soc_array[t] = deepcopy(soc)
 
             # Record the curtailment at the current time step. Adjust `charge` from storage view to
             # outside view for curtailment
-            unused_commodity_array[t] = max(0.0, unused_input - charge / charge_efficiency)
+            # unused_commodity_array[t] = max(0.0, unused_input - charge / charge_efficiency)
 
             # Record the missed load at the current time step
-            unmet_demand_array[t] = max(0.0, (demand_t - total_output_array[t]))
+            # unmet_demand_array[t] = max(0.0, (demand_t - total_output_array[t]))
 
         outputs[f"{commodity}_set_point"] = output_array
-
-        # # Return the SOC
-        # outputs[f"{commodity}_soc"] = soc_array
-
-        # # Return the unused commodity
-        # outputs[f"{commodity}_unused_commodity"] = unused_commodity_array
-
-        # # Return the unmet load demand
-        # outputs[f"{commodity}_unmet_demand"] = unmet_demand_array
-
-        # # Calculate and return the total unmet demand over the simulation period
-        # outputs[f"total_{commodity}_unmet_demand"] = np.sum(unmet_demand_array)
-
-        # # Output the storage duration in hours
-        # outputs["storage_duration"] = max_capacity / max_discharge_rate

--- a/h2integrate/control/control_strategies/storage/demand_openloop_controller.py
+++ b/h2integrate/control/control_strategies/storage/demand_openloop_controller.py
@@ -281,6 +281,7 @@ class DemandOpenLoopStorageController(DemandOpenLoopControlBase):
         unused_commodity_array = outputs[f"{commodity}_unused_commodity"]
         output_array = outputs[f"{commodity}_set_point"]
         unmet_demand_array = outputs[f"{commodity}_unmet_demand"]
+        total_output_array = np.zeros(len(output_array))
 
         # Loop through each time step
         for t, demand_t in enumerate(demand_profile):
@@ -309,7 +310,8 @@ class DemandOpenLoopStorageController(DemandOpenLoopControlBase):
                 soc -= discharge / max_capacity  # soc is a ratio with value between 0 and 1
                 # output is as observed outside the storage, so we need to adjust `discharge` by
                 # applying `discharge_efficiency`.
-                output_array[t] = input_flow + discharge * discharge_efficiency
+                total_output_array[t] = input_flow + discharge * discharge_efficiency
+                output_array[t] = discharge * discharge_efficiency
             else:
                 # Charge storage with unused input
                 # `unused_input` is as seen outside the storage
@@ -323,7 +325,8 @@ class DemandOpenLoopStorageController(DemandOpenLoopControlBase):
                     * charge_efficiency
                 )
                 soc += charge / max_capacity  # soc is a ratio with value between 0 and 1
-                output_array[t] = demand_t
+                output_array[t] = -1 * charge * charge_efficiency
+                total_output_array[t] = demand_t
 
             # Ensure SOC stays within bounds
             soc = max(min_charge_fraction, min(max_charge_fraction, soc))
@@ -336,7 +339,7 @@ class DemandOpenLoopStorageController(DemandOpenLoopControlBase):
             unused_commodity_array[t] = max(0.0, unused_input - charge / charge_efficiency)
 
             # Record the missed load at the current time step
-            unmet_demand_array[t] = max(0.0, (demand_t - output_array[t]))
+            unmet_demand_array[t] = max(0.0, (demand_t - total_output_array[t]))
 
         outputs[f"{commodity}_set_point"] = output_array
 

--- a/h2integrate/control/test/test_openloop_controllers.py
+++ b/h2integrate/control/test/test_openloop_controllers.py
@@ -50,6 +50,8 @@ def test_pass_through_controller(subtests):
     with tech_config_path.open() as file:
         tech_config = yaml.safe_load(file)
 
+    plant_config = {"plant": {"simulation": {"n_timesteps": 10}}}
+
     # Set up the OpenMDAO problem
     prob = om.Problem()
 
@@ -62,7 +64,7 @@ def test_pass_through_controller(subtests):
     prob.model.add_subsystem(
         "pass_through_controller",
         PassThroughOpenLoopController(
-            plant_config={}, tech_config=tech_config["technologies"]["h2_storage"]
+            plant_config=plant_config, tech_config=tech_config["technologies"]["h2_storage"]
         ),
         promotes=["*"],
     )
@@ -75,7 +77,7 @@ def test_pass_through_controller(subtests):
     with subtests.test("Check output"):
         assert pytest.approx(
             prob.get_val("hydrogen_set_point", units="kg/h"), rel=1e-3
-        ) == np.arange(10)
+        ) == np.arange(4.5, -5.5, -1)
 
     # Run the test
     with subtests.test("Check derivatives"):
@@ -152,7 +154,7 @@ def test_storage_demand_controller(subtests):
 
     # Run the test
     with subtests.test("Check output"):
-        assert pytest.approx([0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]) == prob.get_val(
+        assert pytest.approx(np.concat([np.array([0.5, 0.0, -0.5]), np.zeros(7)])) == prob.get_val(
             "hydrogen_set_point", units="kg/h"
         )
 
@@ -291,19 +293,19 @@ def test_generic_storage_demand_controller(subtests):
         "model_inputs": {
             "shared_parameters": {
                 "commodity": "hydrogen",
-                "commodity_rate_units": "kg",
+                "commodity_rate_units": "kg/h",
                 "max_capacity": 10.0,  # kg
                 "max_charge_rate": 1.0,  # fraction (0-1)
-            },
-            "control_parameters": {
                 "max_charge_fraction": 1.0,  # fraction (0-1)
                 "min_charge_fraction": 0.0,  # fraction (0-1)
                 "init_charge_fraction": 1.0,  # fraction (0-1)
-                "max_discharge_rate": 0.5,  # kg/time step
                 "charge_efficiency": 1.0,
+                "demand_profile": [1.0] * 10,  # Example: 10 time steps with 10 kg/time step demand
+            },
+            "control_parameters": {
+                "max_discharge_rate": 0.5,  # kg/time step
                 "charge_equals_discharge": False,
                 "discharge_efficiency": 1.0,
-                "demand_profile": [1.0] * 10,  # Example: 10 time steps with 10 kg/time step demand
             },
         },
     }
@@ -333,7 +335,7 @@ def test_generic_storage_demand_controller(subtests):
 
     # # Run the test
     with subtests.test("Check output"):
-        assert pytest.approx([0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]) == prob.get_val(
+        assert pytest.approx(np.concat([np.array([0.5, 0.0, -0.5]), np.zeros(7)])) == prob.get_val(
             "hydrogen_set_point"
         )
 

--- a/h2integrate/control/test/test_openloop_controllers.py
+++ b/h2integrate/control/test/test_openloop_controllers.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 import openmdao.api as om
 from pytest import fixture
-from openmdao.utils.assert_utils import assert_check_totals
 
 from h2integrate.control.control_strategies.passthrough_openloop_controller import (
     PassThroughOpenLoopController,
@@ -78,24 +77,6 @@ def test_pass_through_controller(subtests):
         assert pytest.approx(
             prob.get_val("hydrogen_set_point", units="kg/h"), rel=1e-3
         ) == np.arange(4.5, -5.5, -1)
-
-    # Run the test
-    with subtests.test("Check derivatives"):
-        # check total derivatives using OpenMDAO's check_totals and assert tools
-        assert_check_totals(
-            prob.check_totals(
-                of=[
-                    "hydrogen_set_point",
-                ],
-                wrt=[
-                    "hydrogen_in",
-                ],
-                step=1e-6,
-                form="central",
-                show_only_incorrect=False,
-                out_stream=None,
-            )
-        )
 
 
 @pytest.mark.regression

--- a/h2integrate/control/test/test_openloop_controllers.py
+++ b/h2integrate/control/test/test_openloop_controllers.py
@@ -7,6 +7,7 @@ import pytest
 import openmdao.api as om
 from pytest import fixture
 
+from h2integrate.storage.simple_generic_storage import SimpleGenericStorage
 from h2integrate.control.control_strategies.passthrough_openloop_controller import (
     PassThroughOpenLoopController,
 )
@@ -91,13 +92,15 @@ def test_storage_demand_controller(subtests):
     with tech_config_path.open() as file:
         tech_config = yaml.safe_load(file)
 
-    plant_config = {"plant": {"simulation": {"n_timesteps": 10}}}
+    # plant_config = {"plant": {"simulation": {"n_timesteps": 10, "dt": 3600}}}
 
     tech_config["technologies"]["h2_storage"]["control_strategy"]["model"] = (
         "DemandOpenLoopStorageController"
     )
 
-    tech_config["technologies"]["h2_storage"]["model_inputs"]["control_parameters"] = {
+    shared_parameters = {
+        "commodity": "hydrogen",
+        "commodity_rate_units": "kg/h",
         "max_capacity": 10.0,  # kg
         "max_charge_fraction": 1.0,  # fraction (0-1)
         "min_charge_fraction": 0.0,  # fraction (0-1)
@@ -109,21 +112,32 @@ def test_storage_demand_controller(subtests):
         "discharge_efficiency": 1.0,
         "demand_profile": [1.0] * 10,  # Example: 10 time steps with 10 kg/time step demand
     }
+    tech_config["technologies"]["h2_storage"]["model_inputs"]["shared_parameters"] = (
+        shared_parameters
+    )
 
-    plant_config = {"plant": {"plant_life": 30, "simulation": {"n_timesteps": 10}}}
+    plant_config = {"plant": {"plant_life": 30, "simulation": {"n_timesteps": 10, "dt": 3600}}}
 
     # Set up the OpenMDAO problem
     prob = om.Problem()
 
     prob.model.add_subsystem(
         name="IVC",
-        subsys=om.IndepVarComp(name="hydrogen_in", val=np.arange(10)),
+        subsys=om.IndepVarComp(name="hydrogen_in", val=np.arange(10), units="kg/h"),
         promotes=["*"],
     )
 
     prob.model.add_subsystem(
         "demand_open_loop_storage_controller",
         DemandOpenLoopStorageController(
+            plant_config=plant_config, tech_config=tech_config["technologies"]["h2_storage"]
+        ),
+        promotes=["*"],
+    )
+
+    prob.model.add_subsystem(
+        "h2_storage",
+        SimpleGenericStorage(
             plant_config=plant_config, tech_config=tech_config["technologies"]["h2_storage"]
         ),
         promotes=["*"],
@@ -136,22 +150,22 @@ def test_storage_demand_controller(subtests):
     # Run the test
     with subtests.test("Check output"):
         assert pytest.approx(np.concat([np.array([0.5, 0.0, -0.5]), np.zeros(7)])) == prob.get_val(
-            "hydrogen_set_point", units="kg/h"
+            "demand_open_loop_storage_controller.hydrogen_set_point", units="kg/h"
         )
 
     with subtests.test("Check curtailment"):
         assert pytest.approx([0.0, 0.0, 0.5, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]) == prob.get_val(
-            "hydrogen_unused_commodity", units="kg/h"
+            "unused_hydrogen_out", units="kg/h"
         )
 
     with subtests.test("Check soc"):
         assert pytest.approx([0.95, 0.95, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]) == prob.get_val(
-            "hydrogen_soc", units="unitless"
+            "SOC", units="unitless"
         )
 
     with subtests.test("Check missed load"):
         assert pytest.approx([0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]) == prob.get_val(
-            "hydrogen_unmet_demand", units="kg/h"
+            "unmet_hydrogen_demand_out", units="kg/h"
         )
 
 
@@ -167,12 +181,12 @@ def test_storage_demand_controller_round_trip_efficiency(subtests):
     with tech_config_path.open() as file:
         tech_config = yaml.safe_load(file)
 
-    plant_config = {"plant": {"simulation": {"n_timesteps": 10}}}
-
     tech_config["technologies"]["h2_storage"]["control_strategy"]["model"] = (
         "DemandOpenLoopStorageController"
     )
-    tech_config["technologies"]["h2_storage"]["model_inputs"]["control_parameters"] = {
+    tech_config["technologies"]["h2_storage"]["model_inputs"]["shared_parameters"] = {
+        "commodity": "hydrogen",
+        "commodity_rate_units": "kg/h",
         "max_capacity": 10.0,  # kg
         "max_charge_fraction": 1.0,  # fraction (0-1)
         "min_charge_fraction": 0.0,  # fraction (0-1)
@@ -186,7 +200,9 @@ def test_storage_demand_controller_round_trip_efficiency(subtests):
     }
 
     tech_config_rte = deepcopy(tech_config)
-    tech_config_rte["technologies"]["h2_storage"]["model_inputs"]["control_parameters"] = {
+    tech_config_rte["technologies"]["h2_storage"]["model_inputs"]["shared_parameters"] = {
+        "commodity": "hydrogen",
+        "commodity_rate_units": "kg/h",
         "max_capacity": 10.0,  # kg
         "max_charge_fraction": 1.0,  # fraction (0-1)
         "min_charge_fraction": 0.0,  # fraction (0-1)
@@ -198,7 +214,7 @@ def test_storage_demand_controller_round_trip_efficiency(subtests):
         "demand_profile": [1.0] * 10,  # Example: 10 time steps with 10 kg/time step demand
     }
 
-    plant_config = {"plant": {"plant_life": 30, "simulation": {"n_timesteps": 10}}}
+    plant_config = {"plant": {"plant_life": 30, "simulation": {"n_timesteps": 10, "dt": 3600}}}
 
     def set_up_and_run_problem(config):
         # Set up the OpenMDAO problem
@@ -206,7 +222,7 @@ def test_storage_demand_controller_round_trip_efficiency(subtests):
 
         prob.model.add_subsystem(
             name="IVC",
-            subsys=om.IndepVarComp(name="hydrogen_in", val=np.arange(10)),
+            subsys=om.IndepVarComp(name="hydrogen_in", val=np.arange(10), units="kg/h"),
             promotes=["*"],
         )
 
@@ -214,6 +230,14 @@ def test_storage_demand_controller_round_trip_efficiency(subtests):
             "demand_openloop_controller",
             DemandOpenLoopStorageController(
                 plant_config=plant_config, tech_config=config["technologies"]["h2_storage"]
+            ),
+            promotes=["*"],
+        )
+
+        prob.model.add_subsystem(
+            "h2_storage",
+            SimpleGenericStorage(
+                plant_config=plant_config, tech_config=tech_config["technologies"]["h2_storage"]
             ),
             promotes=["*"],
         )
@@ -235,18 +259,18 @@ def test_storage_demand_controller_round_trip_efficiency(subtests):
 
     with subtests.test("Check curtailment"):
         assert pytest.approx(
-            prob_ioe.get_val("hydrogen_unused_commodity", units="kg/h")
-        ) == prob_rte.get_val("hydrogen_unused_commodity", units="kg/h")
+            prob_ioe.get_val("unused_hydrogen_out", units="kg/h")
+        ) == prob_rte.get_val("unused_hydrogen_out", units="kg/h")
 
     with subtests.test("Check soc"):
-        assert pytest.approx(
-            prob_ioe.get_val("hydrogen_soc", units="unitless")
-        ) == prob_rte.get_val("hydrogen_soc", units="unitless")
+        assert pytest.approx(prob_ioe.get_val("SOC", units="unitless")) == prob_rte.get_val(
+            "SOC", units="unitless"
+        )
 
     with subtests.test("Check missed load"):
         assert pytest.approx(
-            prob_ioe.get_val("hydrogen_unmet_demand", units="kg/h")
-        ) == prob_rte.get_val("hydrogen_unmet_demand", units="kg/h")
+            prob_ioe.get_val("unmet_hydrogen_demand_out", units="kg/h")
+        ) == prob_rte.get_val("unmet_hydrogen_demand_out", units="kg/h")
 
 
 @pytest.mark.regression
@@ -282,16 +306,16 @@ def test_generic_storage_demand_controller(subtests):
                 "init_charge_fraction": 1.0,  # fraction (0-1)
                 "charge_efficiency": 1.0,
                 "demand_profile": [1.0] * 10,  # Example: 10 time steps with 10 kg/time step demand
-            },
-            "control_parameters": {
                 "max_discharge_rate": 0.5,  # kg/time step
                 "charge_equals_discharge": False,
                 "discharge_efficiency": 1.0,
             },
+            # "control_parameters": {
+            # },
         },
     }
 
-    plant_config = {"plant": {"plant_life": 30, "simulation": {"n_timesteps": 10}}}
+    plant_config = {"plant": {"plant_life": 30, "simulation": {"n_timesteps": 10, "dt": 3600}}}
 
     # Set up OpenMDAO problem
     prob = om.Problem()
@@ -310,6 +334,14 @@ def test_generic_storage_demand_controller(subtests):
         promotes=["*"],
     )
 
+    prob.model.add_subsystem(
+        "h2_storage",
+        SimpleGenericStorage(
+            plant_config=plant_config, tech_config=tech_config["technologies"]["h2_storage"]
+        ),
+        promotes=["*"],
+    )
+
     prob.setup()
 
     prob.run_model()
@@ -322,17 +354,17 @@ def test_generic_storage_demand_controller(subtests):
 
     with subtests.test("Check curtailment"):
         assert pytest.approx([0.0, 0.0, 0.5, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]) == prob.get_val(
-            "hydrogen_unused_commodity"
+            "unused_hydrogen_out"
         )
 
     with subtests.test("Check soc"):
         assert pytest.approx([0.95, 0.95, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]) == prob.get_val(
-            "hydrogen_soc"
+            "SOC", units="unitless"
         )
 
     with subtests.test("Check missed load"):
         assert pytest.approx([0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]) == prob.get_val(
-            "hydrogen_unmet_demand"
+            "unmet_hydrogen_demand_out"
         )
 
 

--- a/h2integrate/postprocess/test/test_sql_timeseries_to_csv.py
+++ b/h2integrate/postprocess/test/test_sql_timeseries_to_csv.py
@@ -57,7 +57,7 @@ def test_save_csv_all_results(subtests, configuration, run_example_02_sql_fpath)
     res = save_case_timeseries_as_csv(run_example_02_sql_fpath, save_to_file=True)
 
     with subtests.test("Check number of columns"):
-        assert len(res.columns.to_list()) == 34
+        assert len(res.columns.to_list()) == 40
 
     with subtests.test("Check number of rows"):
         assert len(res) == 8760

--- a/h2integrate/storage/simple_generic_storage.py
+++ b/h2integrate/storage/simple_generic_storage.py
@@ -138,7 +138,7 @@ class SimpleGenericStorage(PerformanceModelBaseClass):
         #     0, inputs[f"{self.commodity}_demand"] - combined_commodity_out
         # )
 
-        discharge_storage = np.where(storage_commodity_out > 0, storage_commodity_out, 0)
+        np.where(storage_commodity_out > 0, storage_commodity_out, 0)
 
         # TODO: update the below outputs
         # Pass the commodity_out as the commodity_set_point
@@ -148,7 +148,7 @@ class SimpleGenericStorage(PerformanceModelBaseClass):
         outputs[f"rated_{self.commodity}_production"] = inputs["max_charge_rate"]
 
         # Calculate the total and annual commodity produced
-        outputs[f"total_{self.commodity}_produced"] = discharge_storage.sum()
+        outputs[f"total_{self.commodity}_produced"] = outputs[f"{self.commodity}_out"].sum()
         outputs[f"annual_{self.commodity}_produced"] = outputs[
             f"total_{self.commodity}_produced"
         ] * (1 / self.fraction_of_year_simulated)

--- a/h2integrate/storage/simple_generic_storage.py
+++ b/h2integrate/storage/simple_generic_storage.py
@@ -138,7 +138,7 @@ class SimpleGenericStorage(PerformanceModelBaseClass):
         if not self.config.charge_equals_discharge:
             self.add_input(
                 "max_discharge_rate",
-                val=0.0,
+                val=self.config.max_discharge_rate,
                 shape=1,
                 units=self.commodity_rate_units,
                 desc="Storage discharge rate",

--- a/h2integrate/storage/simple_generic_storage.py
+++ b/h2integrate/storage/simple_generic_storage.py
@@ -9,16 +9,21 @@ from h2integrate.core.model_baseclasses import PerformanceModelBaseClass
 @define(kw_only=True)
 class SimpleGenericStorageConfig(BaseConfig):
     commodity: str = field()
-    commodity_rate_units: str = field()  # TODO: update to commodity_rate_units
+    commodity_rate_units: str = field()
     max_charge_rate: float = field(validator=gte_zero)
     max_capacity: float = field()
+    demand_profile: int | float | list = field()
     max_charge_fraction: float = field(validator=range_val(0, 1))
     min_charge_fraction: float = field(validator=range_val(0, 1))
     init_charge_fraction: float = field(validator=range_val(0, 1))
+
+    commodity_amount_units: str = field(default=None)
+    max_discharge_rate: float | None = field(default=None)
+    charge_equals_discharge: bool = field(default=True)
+
     charge_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
     discharge_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
     round_trip_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
-    demand_profile: int | float | list = field()
 
     def __attrs_post_init__(self):
         """
@@ -32,9 +37,11 @@ class SimpleGenericStorageConfig(BaseConfig):
         if self.round_trip_efficiency is not None:
             if self.charge_efficiency is not None or self.discharge_efficiency is not None:
                 raise ValueError(
-                    "Provide either `round_trip_efficiency` or both `charge_efficiency` "
-                    "and `discharge_efficiency`, but not both."
+                    "Exactly one of the following sets of parameters must be set: (a) "
+                    "`round_trip_efficiency`, or (b) both `charge_efficiency` "
+                    "and `discharge_efficiency`."
                 )
+
             # Calculate charge and discharge efficiencies from round-trip efficiency
             self.charge_efficiency = np.sqrt(self.round_trip_efficiency)
             self.discharge_efficiency = np.sqrt(self.round_trip_efficiency)
@@ -43,9 +50,34 @@ class SimpleGenericStorageConfig(BaseConfig):
             pass
         else:
             raise ValueError(
-                "You must provide either `round_trip_efficiency` or both "
-                "`charge_efficiency` and `discharge_efficiency`."
+                "Exactly one of the following sets of parameters must be set: (a) "
+                "`round_trip_efficiency`, or (b) both `charge_efficiency` "
+                "and `discharge_efficiency`."
             )
+
+        if self.charge_equals_discharge:
+            if (
+                self.max_discharge_rate is not None
+                and self.max_discharge_rate != self.max_charge_rate
+            ):
+                msg = (
+                    "Max discharge rate does not equal max charge rate but charge_equals_discharge "
+                    f"is True. Discharge rate is {self.max_discharge_rate} and charge rate "
+                    f"is {self.max_charge_rate}."
+                )
+                raise ValueError(msg)
+
+            self.max_discharge_rate = self.max_charge_rate
+
+        if not self.charge_equals_discharge and self.max_discharge_rate is None:
+            msg = (
+                "max_discharge_rate is required when charge_equals_discharge is False. "
+                "Please input the discharge rate using the key `max_discharge_rate`."
+            )
+            raise ValueError(msg)
+
+        if self.commodity_amount_units is None:
+            self.commodity_amount_units = f"({self.commodity_rate_units})*h"
 
 
 class SimpleGenericStorage(PerformanceModelBaseClass):
@@ -66,7 +98,8 @@ class SimpleGenericStorage(PerformanceModelBaseClass):
         )
         self.commodity = self.config.commodity
         self.commodity_rate_units = self.config.commodity_rate_units
-        self.commodity_amount_units = f"({self.commodity_rate_units})*h"
+        self.commodity_amount_units = self.config.commodity_amount_units
+
         super().setup()
         self.add_input(
             f"{self.commodity}_set_point",
@@ -89,6 +122,7 @@ class SimpleGenericStorage(PerformanceModelBaseClass):
             shape=self.n_timesteps,
             desc=f"{self.commodity} demand profile timeseries",
         )
+
         self.add_input(
             "max_charge_rate",
             val=self.config.max_charge_rate,
@@ -101,6 +135,65 @@ class SimpleGenericStorage(PerformanceModelBaseClass):
             units=self.commodity_amount_units,
             desc="Storage capacity",
         )
+        if not self.config.charge_equals_discharge:
+            self.add_input(
+                "max_discharge_rate",
+                val=0.0,
+                shape=1,
+                units=self.commodity_rate_units,
+                desc="Storage discharge rate",
+            )
+
+        self.add_output(
+            "storage_duration",
+            units=f"({self.commodity_amount_units})/({self.commodity_rate_units})",
+            desc="Estimated storage duration based on max capacity and discharge rate",
+        )
+        # Set storage performance outputs
+        self.add_output(
+            f"unmet_{self.commodity}_demand_out",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.commodity_rate_units,
+            desc=f"Unmet {self.commodity} demand",
+        )
+
+        self.add_output(
+            f"unused_{self.commodity}_out",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.commodity_rate_units,
+            desc="Unused generated commodity",
+        )
+        self.add_output(
+            f"storage_{self.commodity}_out",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.commodity_rate_units,
+            desc=f"{self.commodity} input and output from storage",
+        )
+        self.add_output(
+            f"storage_{self.commodity}_discharge",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.commodity_rate_units,
+            desc=f"{self.commodity} output from storage only",
+        )
+
+        self.add_output(
+            f"storage_{self.commodity}_charge",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.commodity_rate_units,
+            desc=f"{self.commodity} input to storage only",
+        )
+        self.add_output(
+            "SOC",
+            val=0.0,
+            shape=self.n_timesteps,
+            units="percent",
+            desc="State of charge of storage",
+        )
 
         self.dt_hr = int(self.options["plant_config"]["plant"]["simulation"]["dt"]) / (
             60**2
@@ -109,14 +202,17 @@ class SimpleGenericStorage(PerformanceModelBaseClass):
     def compute(self, inputs, outputs):
         self.current_soc = float(self.config.init_charge_fraction)
 
+        if self.config.charge_equals_discharge:
+            discharge_rate = inputs["max_charge_rate"][0]
+        else:
+            discharge_rate = inputs["max_discharge_rate"][0]
         storage_commodity_out, soc = self.simulate(
             storage_dispatch_commands=inputs[f"{self.commodity}_set_point"],
             charge_rate=inputs["max_charge_rate"][0],
-            discharge_rate=inputs["max_charge_rate"][0],
+            discharge_rate=discharge_rate,
             storage_capacity=inputs["storage_capacity"][0],
         )
 
-        # determine storage charge and discharge
         # storage_commodity_out is positive when the storage is discharged
         # and negative when the storage is charged
         storage_commodity_out = np.array(storage_commodity_out)
@@ -129,36 +225,54 @@ class SimpleGenericStorage(PerformanceModelBaseClass):
         total_commodity_out = np.minimum(inputs[f"{self.commodity}_demand"], combined_commodity_out)
 
         # determine how much of the inflow commodity was unused
-        # unused_commodity = np.maximum(
-        #     0, combined_commodity_out - inputs[f"{self.commodity}_demand"]
-        # )
+        unused_commodity = np.maximum(
+            0, combined_commodity_out - inputs[f"{self.commodity}_demand"]
+        )
 
-        # # determine how much demand was not met
-        # unmet_demand = np.maximum(
-        #     0, inputs[f"{self.commodity}_demand"] - combined_commodity_out
-        # )
+        # determine how much demand was not met
+        unmet_demand = np.maximum(0, inputs[f"{self.commodity}_demand"] - combined_commodity_out)
 
-        np.where(storage_commodity_out > 0, storage_commodity_out, 0)
+        outputs["storage_duration"] = inputs["storage_capacity"] / discharge_rate
 
-        # TODO: update the below outputs
-        # Pass the commodity_out as the commodity_set_point
+        # Output the storage performance timeseries
+
+        # storage_commodity_charge is the charge profile and is always <=0
+        outputs[f"storage_{self.commodity}_charge"] = np.where(
+            storage_commodity_out < 0, storage_commodity_out, 0
+        )
+        # storage_commodity_discharge is the discharge profile and is always <=0
+        outputs[f"storage_{self.commodity}_discharge"] = np.where(
+            storage_commodity_out > 0, storage_commodity_out, 0
+        )
+
+        outputs[f"unmet_{self.commodity}_demand_out"] = unmet_demand
+        outputs[f"unused_{self.commodity}_out"] = unused_commodity
+        outputs["SOC"] = soc
+        # storage_commodity_out is the combined charge and discharge profile
+        outputs[f"storage_{self.commodity}_out"] = storage_commodity_out
+
+        # commodity_out is the commodity_in - charge_storage + discharge_storage
         outputs[f"{self.commodity}_out"] = total_commodity_out
 
-        # Set the rated commodity production from the max_charge_rate input
-        outputs[f"rated_{self.commodity}_production"] = inputs["max_charge_rate"]
+        # Output the standard performance model outputs
+        # The rated_commodity_production is based on the discharge rate
+        outputs[f"rated_{self.commodity}_production"] = discharge_rate
 
-        # Calculate the total and annual commodity produced
+        # The total_commodity_produced is the sum of the commodity to meet demand
         outputs[f"total_{self.commodity}_produced"] = outputs[f"{self.commodity}_out"].sum()
+
+        # Adjust the total_commodity_produced to a year-long simulation
         outputs[f"annual_{self.commodity}_produced"] = outputs[
             f"total_{self.commodity}_produced"
         ] * (1 / self.fraction_of_year_simulated)
 
         # Calculate the maximum theoretical commodity production over the simulation
-        rated_production = (
+        max_production = (
             outputs[f"rated_{self.commodity}_production"] * self.n_timesteps * (self.dt / 3600)
         )
 
-        outputs["capacity_factor"] = outputs[f"total_{self.commodity}_produced"] / rated_production
+        # Capacity factor is total commodity produced / maximum discharged commodity possible
+        outputs["capacity_factor"] = outputs[f"total_{self.commodity}_produced"] / max_production
 
     def simulate(
         self,

--- a/h2integrate/storage/simple_generic_storage.py
+++ b/h2integrate/storage/simple_generic_storage.py
@@ -1,7 +1,8 @@
+import numpy as np
 from attrs import field, define
 
 from h2integrate.core.utilities import BaseConfig, merge_shared_inputs
-from h2integrate.core.validators import gte_zero
+from h2integrate.core.validators import gte_zero, range_val, range_val_or_none
 from h2integrate.core.model_baseclasses import PerformanceModelBaseClass
 
 
@@ -10,6 +11,41 @@ class SimpleGenericStorageConfig(BaseConfig):
     commodity: str = field()
     commodity_rate_units: str = field()  # TODO: update to commodity_rate_units
     max_charge_rate: float = field(validator=gte_zero)
+    max_capacity: float = field()
+    max_charge_fraction: float = field(validator=range_val(0, 1))
+    min_charge_fraction: float = field(validator=range_val(0, 1))
+    init_charge_fraction: float = field(validator=range_val(0, 1))
+    charge_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
+    discharge_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
+    round_trip_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
+    demand_profile: int | float | list = field()
+
+    def __attrs_post_init__(self):
+        """
+        Post-initialization logic to validate and calculate efficiencies.
+
+        Ensures that either `charge_efficiency` and `discharge_efficiency` are provided,
+        or `round_trip_efficiency` is provided. If `round_trip_efficiency` is provided,
+        it calculates `charge_efficiency` and `discharge_efficiency` as the square root
+        of `round_trip_efficiency`.
+        """
+        if self.round_trip_efficiency is not None:
+            if self.charge_efficiency is not None or self.discharge_efficiency is not None:
+                raise ValueError(
+                    "Provide either `round_trip_efficiency` or both `charge_efficiency` "
+                    "and `discharge_efficiency`, but not both."
+                )
+            # Calculate charge and discharge efficiencies from round-trip efficiency
+            self.charge_efficiency = np.sqrt(self.round_trip_efficiency)
+            self.discharge_efficiency = np.sqrt(self.round_trip_efficiency)
+        elif self.charge_efficiency is not None and self.discharge_efficiency is not None:
+            # Ensure both charge and discharge efficiencies are provided
+            pass
+        else:
+            raise ValueError(
+                "You must provide either `round_trip_efficiency` or both "
+                "`charge_efficiency` and `discharge_efficiency`."
+            )
 
 
 class SimpleGenericStorage(PerformanceModelBaseClass):
@@ -39,21 +75,80 @@ class SimpleGenericStorage(PerformanceModelBaseClass):
             units=self.commodity_rate_units,
         )
         self.add_input(
+            f"{self.commodity}_in",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.commodity_rate_units,
+            desc=f"Amount of {self.commodity} demand that has already been supplied",
+        )
+
+        self.add_input(
+            f"{self.commodity}_demand",
+            units=f"{self.config.commodity_rate_units}",
+            val=self.config.demand_profile,
+            shape=self.n_timesteps,
+            desc=f"{self.commodity} demand profile timeseries",
+        )
+        self.add_input(
             "max_charge_rate",
             val=self.config.max_charge_rate,
             units=self.config.commodity_rate_units,
             desc="Storage charge/discharge rate",
         )
+        self.add_input(
+            "storage_capacity",
+            val=self.config.max_capacity,
+            units=self.commodity_amount_units,
+            desc="Storage capacity",
+        )
+
+        self.dt_hr = int(self.options["plant_config"]["plant"]["simulation"]["dt"]) / (
+            60**2
+        )  # convert from seconds to hours
 
     def compute(self, inputs, outputs):
+        self.current_soc = float(self.config.init_charge_fraction)
+
+        storage_commodity_out, soc = self.simulate(
+            storage_dispatch_commands=inputs[f"{self.commodity}_set_point"],
+            charge_rate=inputs["max_charge_rate"][0],
+            discharge_rate=inputs["max_charge_rate"][0],
+            storage_capacity=inputs["storage_capacity"][0],
+        )
+
+        # determine storage charge and discharge
+        # storage_commodity_out is positive when the storage is discharged
+        # and negative when the storage is charged
+        storage_commodity_out = np.array(storage_commodity_out)
+
+        # calculate combined commodity out from inflow source and storage
+        # (note: storage_commodity_out is negative when charging)
+        combined_commodity_out = inputs[f"{self.commodity}_in"] + storage_commodity_out
+
+        # find the total commodity out to meet demand
+        total_commodity_out = np.minimum(inputs[f"{self.commodity}_demand"], combined_commodity_out)
+
+        # determine how much of the inflow commodity was unused
+        # unused_commodity = np.maximum(
+        #     0, combined_commodity_out - inputs[f"{self.commodity}_demand"]
+        # )
+
+        # # determine how much demand was not met
+        # unmet_demand = np.maximum(
+        #     0, inputs[f"{self.commodity}_demand"] - combined_commodity_out
+        # )
+
+        discharge_storage = np.where(storage_commodity_out > 0, storage_commodity_out, 0)
+
+        # TODO: update the below outputs
         # Pass the commodity_out as the commodity_set_point
-        outputs[f"{self.commodity}_out"] = inputs[f"{self.commodity}_set_point"]
+        outputs[f"{self.commodity}_out"] = total_commodity_out
 
         # Set the rated commodity production from the max_charge_rate input
         outputs[f"rated_{self.commodity}_production"] = inputs["max_charge_rate"]
 
         # Calculate the total and annual commodity produced
-        outputs[f"total_{self.commodity}_produced"] = outputs[f"{self.commodity}_out"].sum()
+        outputs[f"total_{self.commodity}_produced"] = discharge_storage.sum()
         outputs[f"annual_{self.commodity}_produced"] = outputs[
             f"total_{self.commodity}_produced"
         ] * (1 / self.fraction_of_year_simulated)
@@ -64,3 +159,123 @@ class SimpleGenericStorage(PerformanceModelBaseClass):
         )
 
         outputs["capacity_factor"] = outputs[f"total_{self.commodity}_produced"] / rated_production
+
+    def simulate(
+        self,
+        storage_dispatch_commands: list,
+        charge_rate: float,
+        discharge_rate: float,
+        storage_capacity: float,
+        sim_start_index: int = 0,
+    ):
+        """Run the storage model over a control window of ``n_control_window`` timesteps.
+
+        Iterates through ``storage_dispatch_commands`` one timestep at a time.
+        A negative command requests charging; a positive command requests
+        discharging.  Each command is clipped to the most restrictive of three
+        limits before it is applied:
+
+        1. **SOC headroom** - the remaining capacity (charge) or remaining
+           stored commodity (discharge), converted to a rate via
+           ``storage_capacity / dt_hr``.
+        2. **Hardware rate limit** - ``charge_rate`` or ``discharge_rate``,
+           divided by the corresponding efficiency so the limit is expressed
+           in pre-efficiency rate units.
+        3. **Commanded magnitude** - the absolute value of the dispatch command
+           itself (we never exceed what was asked for).
+
+        After clipping, the result is scaled by the charge or discharge
+        efficiency to obtain the actual commodity flow into or out of the
+        storage, and the SOC is updated accordingly.
+
+        This method is separated from ``compute()`` so the Pyomo dispatch
+        controller can call it directly to evaluate candidate schedules.
+
+        Args:
+            storage_dispatch_commands (array_like[float]):
+                Dispatch set-points for each timestep in ``commodity_rate_units``.
+                Negative values command charging; positive values command
+                discharging.  Length must equal ``config.n_control_window``.
+            charge_rate (float):
+                Maximum commodity input rate to storage in
+                ``commodity_rate_units`` (before charge efficiency is applied).
+            discharge_rate (float):
+                Maximum commodity output rate from storage in
+                ``commodity_rate_units`` (before discharge efficiency is applied).
+            storage_capacity (float):
+                Rated storage capacity in ``commodity_amount_units``.
+            sim_start_index (int, optional):
+                Starting index for writing into persistent output arrays.
+                Defaults to 0.
+
+        Returns:
+            tuple[np.ndarray, np.ndarray]
+                storage_commodity_out_timesteps :
+                    Commodity flow per timestep in ``commodity_rate_units``.
+                    Positive = discharge (commodity leaving storage),
+                    negative = charge (commodity entering storage).
+                soc_timesteps :
+                    State of charge at the end of each timestep, in percent
+                    (0-100).
+        """
+
+        n = len(storage_dispatch_commands)
+        storage_commodity_out_timesteps = np.zeros(n)
+        soc_timesteps = np.zeros(n)
+
+        # Early return when storage cannot operate: zero capacity or both
+        # charge and discharge rates are zero.
+        if storage_capacity <= 0 or (charge_rate <= 0 and discharge_rate <= 0):
+            soc_timesteps[:] = self.current_soc * 100.0
+            return storage_commodity_out_timesteps, soc_timesteps
+
+        # Pre-compute scalar constants to avoid repeated attribute lookups
+        # and redundant divisions inside the per-timestep loop.
+        charge_eff = self.config.charge_efficiency
+        discharge_eff = self.config.discharge_efficiency
+        soc_max = self.config.max_charge_fraction
+        soc_min = self.config.min_charge_fraction
+
+        # max_charge_input / max_discharge_input are the hardware rate limits
+        # expressed in *pre-efficiency* rate units so they can be compared
+        # directly against the SOC headroom and the raw command magnitude.
+        max_charge_input = charge_rate / charge_eff
+        max_discharge_input = discharge_rate / discharge_eff
+
+        commands = np.asarray(storage_dispatch_commands, dtype=float)
+        soc = float(self.current_soc)
+
+        for t, cmd in enumerate(commands):
+            if cmd < 0.0:
+                # --- Charging ---
+                # headroom: how much more commodity the storage can accept,
+                # expressed as a rate (commodity_rate_units).
+                headroom = (soc_max - soc) * storage_capacity / self.dt_hr
+
+                # Clip to the most restrictive limit, then apply efficiency.
+                # max(0, ...) guards against negative headroom when SOC
+                # slightly exceeds soc_max.
+                actual_charge = max(0.0, min(headroom, max_charge_input, -cmd)) * charge_eff
+
+                # Update SOC (actual_charge is in post-efficiency units)
+                soc += actual_charge / storage_capacity
+                storage_commodity_out_timesteps[t] = -actual_charge
+            else:
+                # --- Discharging ---
+                # headroom: how much commodity can still be drawn before
+                # hitting the minimum SOC, expressed as a rate.
+                headroom = (soc - soc_min) * storage_capacity / self.dt_hr
+
+                # Clip and apply discharge efficiency.
+                actual_discharge = max(0.0, min(headroom, max_discharge_input, cmd)) * discharge_eff
+
+                # Update SOC (actual_discharge is in post-efficiency units)
+                soc -= actual_discharge / storage_capacity
+                storage_commodity_out_timesteps[t] = actual_discharge
+
+            soc_timesteps[t] = soc * 100.0
+
+        # Persist the final SOC so subsequent simulate() calls (e.g. from the
+        # Pyomo controller across rolling windows) start where we left off.
+        self.current_soc = soc
+        return storage_commodity_out_timesteps, soc_timesteps

--- a/h2integrate/storage/simple_storage_auto_sizing.py
+++ b/h2integrate/storage/simple_storage_auto_sizing.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 import numpy as np
 from attrs import field, define
 
@@ -76,7 +74,7 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
         super().setup()
 
         self.add_input(
-            f"{self.commodity}_demand_profile",
+            f"{self.commodity}_demand",
             units=f"{self.config.commodity_rate_units}",
             val=self.config.demand_profile,
             shape=self.n_timesteps,
@@ -111,6 +109,10 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
             units=f"{self.config.commodity_rate_units}",
         )
 
+        self.dt_hr = int(self.options["plant_config"]["plant"]["simulation"]["dt"]) / (
+            60**2
+        )  # convert from seconds to hours
+
     def compute(self, inputs, outputs):
         # Step 1: Auto-size the storage to meet the demand
 
@@ -118,28 +120,30 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
         storage_max_fill_rate = np.max(inputs[f"{self.commodity}_in"])
 
         # Set the demand profile
-        if np.sum(inputs[f"{self.commodity}_demand_profile"]) > 0:
-            commodity_demand = inputs[f"{self.commodity}_demand_profile"]
+        if np.sum(inputs[f"{self.commodity}_demand"]) > 0:
+            commodity_demand = inputs[f"{self.commodity}_demand"]
         else:
-            # If the commodity_demand_profile is zero, use the average
+            # If the commodity_demand is zero, use the average
             # commodity_in as the demand
             commodity_demand = np.mean(inputs[f"{self.commodity}_in"]) * np.ones(
                 self.n_timesteps
             )  # TODO: update demand based on end-use needs
 
         # The commodity_set_point is the production set by the controller
-        desired_commodity_production = inputs[f"{self.commodity}_set_point"]
+        # storage_dispatch_commands = inputs[f"{self.commodity}_set_point"]
 
         # TODO: SOC is just an absolute value and is not a percentage. Ideally would calculate as shortfall in future.
         # Size the storage capacity to meet the demand as much as possible
         commodity_storage_soc = []
-        for j in range(len(desired_commodity_production)):
+        for j in range(len(inputs[f"{self.commodity}_in"])):
             if j == 0:
-                commodity_storage_soc.append(desired_commodity_production[j] - commodity_demand[j])
+                commodity_storage_soc.append(
+                    inputs[f"{self.commodity}_in"][j] - commodity_demand[j]
+                )
             else:
                 commodity_storage_soc.append(
                     commodity_storage_soc[j - 1]
-                    + desired_commodity_production[j]
+                    + inputs[f"{self.commodity}_in"][j]
                     - commodity_demand[j]
                 )
 
@@ -155,49 +159,45 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
         )
 
         # Step 2: Simulate the storage performance based on the sizes calculated
+        self.current_soc = commodity_storage_soc[0] / commodity_storage_capacity_kg
 
-        # Initialize output arrays of charge and discharge
-        discharge_storage = np.zeros(self.n_timesteps)
-        charge_storage = np.zeros(self.n_timesteps)
-        output_array = np.zeros(self.n_timesteps)
+        storage_commodity_out, soc = self.simulate(
+            storage_dispatch_commands=inputs[f"{self.commodity}_set_point"],
+            charge_rate=storage_max_fill_rate,
+            discharge_rate=storage_max_fill_rate,
+            storage_capacity=commodity_storage_capacity_kg,
+        )
 
-        # Initialize state-of-charge value as the soc at t=0
-        soc = deepcopy(commodity_storage_soc[0])
+        # determine storage charge and discharge
+        # storage_commodity_out is positive when the storage is discharged
+        # and negative when the storage is charged
+        storage_commodity_out = np.array(storage_commodity_out)
 
-        # Simulate a basic storage component
-        for t, demand_t in enumerate(commodity_demand):
-            input_flow = desired_commodity_production[t]
-            available_charge = float(commodity_storage_capacity_kg - soc)
-            available_discharge = float(soc)
+        # calculate combined commodity out from inflow source and storage
+        # (note: storage_commodity_out is negative when charging)
+        combined_commodity_out = inputs[f"{self.commodity}_in"] + storage_commodity_out
 
-            # If demand is greater than the input, discharge storage
-            if demand_t > input_flow:
-                # Discharge storage to meet demand.
-                discharge_needed = demand_t - input_flow
-                discharge = min(discharge_needed, available_discharge, storage_max_fill_rate)
-                # Update SOC
-                soc -= discharge
+        # find the total commodity out to meet demand
+        total_commodity_out = np.minimum(inputs[f"{self.commodity}_demand"], combined_commodity_out)
 
-                discharge_storage[t] = discharge
-                output_array[t] = input_flow + discharge
+        # determine how much of the inflow commodity was unused
+        # unused_commodity = np.maximum(
+        #     0, combined_commodity_out - inputs[f"{self.commodity}_demand"]
+        # )
 
-            # If input is greater than the demand, charge storage
-            else:
-                # Charge storage with unused input
-                unused_input = input_flow - demand_t
-                charge = min(unused_input, available_charge, storage_max_fill_rate)
-                # Update SOC
-                soc += charge
+        # # determine how much demand was not met
+        # unmet_demand = np.maximum(
+        #     0, inputs[f"{self.commodity}_demand"] - combined_commodity_out
+        # )
 
-                charge_storage[t] = charge
-                output_array[t] = demand_t
+        discharge_storage = np.where(storage_commodity_out > 0, storage_commodity_out, 0)
 
         # Output the storage sizes (charge rate and capacity)
         outputs["max_charge_rate"] = storage_max_fill_rate
         outputs["max_capacity"] = commodity_storage_capacity_kg
 
         # commodity_out is the commodity_set_point - charge_storage + discharge_storage
-        outputs[f"{self.commodity}_out"] = output_array
+        outputs[f"{self.commodity}_out"] = total_commodity_out
 
         # The rated_commodity_production is based on the discharge rate
         # (which is assumed equal to the charge rate)
@@ -215,3 +215,123 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
 
         # Capacity factor is total discharged commodity / maximum discharged commodity possible
         outputs["capacity_factor"] = outputs[f"total_{self.commodity}_produced"] / max_production
+
+    def simulate(
+        self,
+        storage_dispatch_commands: list,
+        charge_rate: float,
+        discharge_rate: float,
+        storage_capacity: float,
+        sim_start_index: int = 0,
+    ):
+        """Run the storage model over a control window of ``n_control_window`` timesteps.
+
+        Iterates through ``storage_dispatch_commands`` one timestep at a time.
+        A negative command requests charging; a positive command requests
+        discharging.  Each command is clipped to the most restrictive of three
+        limits before it is applied:
+
+        1. **SOC headroom** - the remaining capacity (charge) or remaining
+           stored commodity (discharge), converted to a rate via
+           ``storage_capacity / dt_hr``.
+        2. **Hardware rate limit** - ``charge_rate`` or ``discharge_rate``,
+           divided by the corresponding efficiency so the limit is expressed
+           in pre-efficiency rate units.
+        3. **Commanded magnitude** - the absolute value of the dispatch command
+           itself (we never exceed what was asked for).
+
+        After clipping, the result is scaled by the charge or discharge
+        efficiency to obtain the actual commodity flow into or out of the
+        storage, and the SOC is updated accordingly.
+
+        This method is separated from ``compute()`` so the Pyomo dispatch
+        controller can call it directly to evaluate candidate schedules.
+
+        Args:
+            storage_dispatch_commands (array_like[float]):
+                Dispatch set-points for each timestep in ``commodity_rate_units``.
+                Negative values command charging; positive values command
+                discharging.  Length must equal ``config.n_control_window``.
+            charge_rate (float):
+                Maximum commodity input rate to storage in
+                ``commodity_rate_units`` (before charge efficiency is applied).
+            discharge_rate (float):
+                Maximum commodity output rate from storage in
+                ``commodity_rate_units`` (before discharge efficiency is applied).
+            storage_capacity (float):
+                Rated storage capacity in ``commodity_amount_units``.
+            sim_start_index (int, optional):
+                Starting index for writing into persistent output arrays.
+                Defaults to 0.
+
+        Returns:
+            tuple[np.ndarray, np.ndarray]
+                storage_commodity_out_timesteps :
+                    Commodity flow per timestep in ``commodity_rate_units``.
+                    Positive = discharge (commodity leaving storage),
+                    negative = charge (commodity entering storage).
+                soc_timesteps :
+                    State of charge at the end of each timestep, in percent
+                    (0-100).
+        """
+
+        n = len(storage_dispatch_commands)
+        storage_commodity_out_timesteps = np.zeros(n)
+        soc_timesteps = np.zeros(n)
+
+        # Early return when storage cannot operate: zero capacity or both
+        # charge and discharge rates are zero.
+        if storage_capacity <= 0 or (charge_rate <= 0 and discharge_rate <= 0):
+            soc_timesteps[:] = self.current_soc * 100.0
+            return storage_commodity_out_timesteps, soc_timesteps
+
+        # Pre-compute scalar constants to avoid repeated attribute lookups
+        # and redundant divisions inside the per-timestep loop.
+        charge_eff = 1.0
+        discharge_eff = 1.0
+        soc_max = 1.0
+        soc_min = 0.0
+
+        # max_charge_input / max_discharge_input are the hardware rate limits
+        # expressed in *pre-efficiency* rate units so they can be compared
+        # directly against the SOC headroom and the raw command magnitude.
+        max_charge_input = charge_rate / charge_eff
+        max_discharge_input = discharge_rate / discharge_eff
+
+        commands = np.asarray(storage_dispatch_commands, dtype=float)
+        soc = float(self.current_soc)
+
+        for t, cmd in enumerate(commands):
+            if cmd < 0.0:
+                # --- Charging ---
+                # headroom: how much more commodity the storage can accept,
+                # expressed as a rate (commodity_rate_units).
+                headroom = (soc_max - soc) * storage_capacity / self.dt_hr
+
+                # Clip to the most restrictive limit, then apply efficiency.
+                # max(0, ...) guards against negative headroom when SOC
+                # slightly exceeds soc_max.
+                actual_charge = max(0.0, min(headroom, max_charge_input, -cmd)) * charge_eff
+
+                # Update SOC (actual_charge is in post-efficiency units)
+                soc += actual_charge / storage_capacity
+                storage_commodity_out_timesteps[t] = -actual_charge
+            else:
+                # --- Discharging ---
+                # headroom: how much commodity can still be drawn before
+                # hitting the minimum SOC, expressed as a rate.
+                headroom = (soc - soc_min) * storage_capacity / self.dt_hr
+
+                # Clip and apply discharge efficiency.
+                actual_discharge = max(0.0, min(headroom, max_discharge_input, cmd)) * discharge_eff
+
+                # Update SOC (actual_discharge is in post-efficiency units)
+                soc -= actual_discharge / storage_capacity
+                storage_commodity_out_timesteps[t] = actual_discharge
+
+            soc_timesteps[t] = soc * 100.0
+
+        # Persist the final SOC so subsequent simulate() calls (e.g. from the
+        # Pyomo controller across rolling windows) start where we left off.
+        self.current_soc = soc
+        return storage_commodity_out_timesteps, soc_timesteps

--- a/h2integrate/storage/simple_storage_auto_sizing.py
+++ b/h2integrate/storage/simple_storage_auto_sizing.py
@@ -154,18 +154,16 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
             commodity_storage_soc = [x + np.abs(minimum_soc) for x in commodity_storage_soc]
 
         # Calculate the maximum hydrogen storage capacity needed to meet the demand
-        commodity_storage_capacity_kg = np.max(commodity_storage_soc) - np.min(
-            commodity_storage_soc
-        )
+        commodity_storage_capacity = np.max(commodity_storage_soc) - np.min(commodity_storage_soc)
 
         # Step 2: Simulate the storage performance based on the sizes calculated
-        self.current_soc = commodity_storage_soc[0] / commodity_storage_capacity_kg
+        self.current_soc = commodity_storage_soc[0] / commodity_storage_capacity
 
         storage_commodity_out, soc = self.simulate(
             storage_dispatch_commands=inputs[f"{self.commodity}_set_point"],
             charge_rate=storage_max_fill_rate,
             discharge_rate=storage_max_fill_rate,
-            storage_capacity=commodity_storage_capacity_kg,
+            storage_capacity=commodity_storage_capacity,
         )
 
         # determine storage charge and discharge
@@ -194,7 +192,7 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
 
         # Output the storage sizes (charge rate and capacity)
         outputs["max_charge_rate"] = storage_max_fill_rate
-        outputs["max_capacity"] = commodity_storage_capacity_kg
+        outputs["max_capacity"] = commodity_storage_capacity
 
         # commodity_out is the commodity_set_point - charge_storage + discharge_storage
         outputs[f"{self.commodity}_out"] = total_commodity_out

--- a/h2integrate/storage/simple_storage_auto_sizing.py
+++ b/h2integrate/storage/simple_storage_auto_sizing.py
@@ -176,7 +176,7 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
         combined_commodity_out = inputs[f"{self.commodity}_in"] + storage_commodity_out
 
         # find the total commodity out to meet demand
-        total_commodity_out = np.minimum(inputs[f"{self.commodity}_demand"], combined_commodity_out)
+        total_commodity_out = np.minimum(commodity_demand, combined_commodity_out)
 
         # determine how much of the inflow commodity was unused
         # unused_commodity = np.maximum(

--- a/h2integrate/storage/simple_storage_auto_sizing.py
+++ b/h2integrate/storage/simple_storage_auto_sizing.py
@@ -163,7 +163,7 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
 
         # Output the calculated storage capacities
         self.add_output(
-            "max_capacity",  # TODO: rename to max_capacity
+            "max_capacity",  # TODO: rename to storage_capacity
             val=0.0,
             shape=1,
             units=f"({self.commodity_rate_units})*h",  # TODO: update to commodity_amount_units

--- a/h2integrate/storage/simple_storage_auto_sizing.py
+++ b/h2integrate/storage/simple_storage_auto_sizing.py
@@ -163,10 +163,10 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
 
         # Output the calculated storage capacities
         self.add_output(
-            "max_capacity",
+            "max_capacity",  # TODO: rename to max_capacity
             val=0.0,
             shape=1,
-            units=f"({self.commodity_rate_units})*h",
+            units=f"({self.commodity_rate_units})*h",  # TODO: update to commodity_amount_units
         )
 
         self.add_output(
@@ -183,6 +183,11 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
                 units=self.commodity_rate_units,
                 desc="Storage discharge rate",
             )
+        self.add_output(
+            "storage_duration",
+            units=f"({self.commodity_amount_units})/({self.commodity_rate_units})",
+            desc="Estimated storage duration based on max capacity and discharge rate",
+        )
         # Set storage performance outputs
         self.add_output(
             f"unmet_{self.commodity}_demand_out",
@@ -327,6 +332,8 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
 
         outputs[f"unmet_{self.commodity}_demand_out"] = unmet_demand
         outputs[f"unused_{self.commodity}_out"] = unused_commodity
+        outputs["SOC"] = soc
+        # storage_commodity_out is the combined charge and discharge profile
         outputs[f"storage_{self.commodity}_out"] = storage_commodity_out
 
         # Output the storage sizes (charge rate and capacity)
@@ -334,14 +341,16 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
         outputs["max_capacity"] = commodity_storage_capacity
         if "max_discharge_rate" in outputs:
             outputs["max_discharge_rate"] = storage_max_unfill_rate
+        outputs["storage_duration"] = outputs["max_capacity"] / storage_max_unfill_rate
 
-        # commodity_out is the commodity_set_point - charge_storage + discharge_storage
+        # commodity_out is the commodity_in - charge_storage + discharge_storage
         outputs[f"{self.commodity}_out"] = total_commodity_out
 
+        # Output the standard performance model outputs
         # The rated_commodity_production is based on the discharge rate
         outputs[f"rated_{self.commodity}_production"] = storage_max_unfill_rate
 
-        # The total_commodity_produced is the sum of the commodity discharged from storage
+        # The total_commodity_produced is the sum of the commodity to meet demand
         outputs[f"total_{self.commodity}_produced"] = np.sum(total_commodity_out)
 
         # Adjust the total_commodity_produced to a year-long simulation

--- a/h2integrate/storage/simple_storage_auto_sizing.py
+++ b/h2integrate/storage/simple_storage_auto_sizing.py
@@ -2,6 +2,7 @@ import numpy as np
 from attrs import field, define
 
 from h2integrate.core.utilities import BaseConfig, merge_shared_inputs
+from h2integrate.core.validators import range_val, range_val_or_none
 from h2integrate.core.model_baseclasses import PerformanceModelBaseClass
 
 
@@ -9,12 +10,77 @@ from h2integrate.core.model_baseclasses import PerformanceModelBaseClass
 class StorageSizingModelConfig(BaseConfig):
     """Configuration class for the StorageAutoSizingModel.
 
-    Fields include `commodity`, `commodity_rate_units`, and `demand_profile`.
+    Attributes:
+        commodity (str): name of commodity. Defaults to "hydrogen".
+        commodity_rate_units (str): Units of the commodity (e.g., "kg/h"). Defaults to "kg/h".
+        demand_profile (int | float | list): Commodity demand in commodity_rate_units. If 0,
+            then assumes the demand is the mean of the input commodity. Defaults to 0.
+        min_charge_fraction (float): Minimum allowable state of charge as a fraction (0 to 1).
+            Defaults to 0.
+        max_charge_fraction (float): Maximum allowable state of charge as a fraction (0 to 1).
+            Defaults to 1.0
+        commodity_amount_units (str | None, optional): Units of the commodity as an amount
+            (i.e., kW*h or kg). If not provided, defaults to commodity_rate_units*h.
+        charge_equals_discharge (bool, optional): If True, outputs the max_discharge_rate
+            in addition to the max_charge_rate.
+        charge_efficiency (float | None, optional): Efficiency of charging the storage, represented
+            as a decimal between 0 and 1 (e.g., 0.9 for 90% efficiency). Optional if
+            `round_trip_efficiency` is provided.
+        discharge_efficiency (float | None, optional): Efficiency of discharging the storage,
+            represented as a decimal between 0 and 1 (e.g., 0.9 for 90% efficiency). Optional if
+            `round_trip_efficiency` is provided.
+        round_trip_efficiency (float | None, optional): Combined efficiency of charging and
+            discharging the storage, represented as a decimal between 0 and 1 (e.g., 0.81 for
+            81% efficiency). Optional if `charge_efficiency` and `discharge_efficiency` are
+            provided.
     """
 
     commodity: str = field(default="hydrogen")
-    commodity_rate_units: str = field(default="kg/h")  # TODO: update to commodity_rate_units
+    commodity_rate_units: str = field(default="kg/h")
     demand_profile: int | float | list = field(default=0.0)
+
+    min_charge_fraction: float = field(default=0.0, validator=range_val(0, 1))
+    max_charge_fraction: float = field(default=1.0, validator=range_val(0, 1))
+
+    commodity_amount_units: str = field(default=None)
+    charge_equals_discharge: bool = field(default=True)
+
+    charge_efficiency: float | None = field(default=1.0, validator=range_val_or_none(0, 1))
+    discharge_efficiency: float | None = field(default=1.0, validator=range_val_or_none(0, 1))
+    round_trip_efficiency: float | None = field(default=None, validator=range_val_or_none(0, 1))
+
+    def __attrs_post_init__(self):
+        """
+        Post-initialization logic to validate and calculate efficiencies.
+
+        Ensures that either `charge_efficiency` and `discharge_efficiency` are provided,
+        or `round_trip_efficiency` is provided. If `round_trip_efficiency` is provided,
+        it calculates `charge_efficiency` and `discharge_efficiency` as the square root
+        of `round_trip_efficiency`.
+        """
+        if self.round_trip_efficiency is not None:
+            if self.charge_efficiency is not None or self.discharge_efficiency is not None:
+                raise ValueError(
+                    "Exactly one of the following sets of parameters must be set: (a) "
+                    "`round_trip_efficiency`, or (b) both `charge_efficiency` "
+                    "and `discharge_efficiency`."
+                )
+
+            # Calculate charge and discharge efficiencies from round-trip efficiency
+            self.charge_efficiency = np.sqrt(self.round_trip_efficiency)
+            self.discharge_efficiency = np.sqrt(self.round_trip_efficiency)
+        elif self.charge_efficiency is not None and self.discharge_efficiency is not None:
+            # Ensure both charge and discharge efficiencies are provided
+            pass
+        else:
+            raise ValueError(
+                "Exactly one of the following sets of parameters must be set: (a) "
+                "`round_trip_efficiency`, or (b) both `charge_efficiency` "
+                "and `discharge_efficiency`."
+            )
+
+        if self.commodity_amount_units is None:
+            self.commodity_amount_units = f"({self.commodity_rate_units})*h"
 
 
 class StorageAutoSizingModel(PerformanceModelBaseClass):
@@ -75,7 +141,7 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
 
         self.add_input(
             f"{self.commodity}_demand",
-            units=f"{self.config.commodity_rate_units}",
+            units=self.commodity_rate_units,
             val=self.config.demand_profile,
             shape=self.n_timesteps,
             desc=f"{self.commodity} demand profile timeseries",
@@ -84,29 +150,83 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
         self.add_input(
             f"{self.commodity}_in",
             shape_by_conn=True,
-            units=f"{self.config.commodity_rate_units}",
+            units=self.commodity_rate_units,
             desc=f"{self.commodity} input timeseries from production to storage",
         )
 
         self.add_input(
             f"{self.commodity}_set_point",
             shape_by_conn=True,
-            units=f"{self.config.commodity_rate_units}",
+            units=self.commodity_rate_units,
             desc=f"{self.commodity} input set point from controller",
         )
 
+        # Output the calculated storage capacities
         self.add_output(
             "max_capacity",
             val=0.0,
             shape=1,
-            units=f"({self.config.commodity_rate_units})*h",
+            units=f"({self.commodity_rate_units})*h",
         )
 
         self.add_output(
             "max_charge_rate",
             val=0.0,
             shape=1,
-            units=f"{self.config.commodity_rate_units}",
+            units=self.commodity_rate_units,
+        )
+        if not self.config.charge_equals_discharge:
+            self.add_output(
+                "max_discharge_rate",
+                val=0.0,
+                shape=1,
+                units=self.commodity_rate_units,
+                desc="Storage discharge rate",
+            )
+        # Set storage performance outputs
+        self.add_output(
+            f"unmet_{self.commodity}_demand_out",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.commodity_rate_units,
+            desc=f"Unmet {self.commodity} demand",
+        )
+
+        self.add_output(
+            f"unused_{self.commodity}_out",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.commodity_rate_units,
+            desc="Unused generated commodity",
+        )
+        self.add_output(
+            f"storage_{self.commodity}_out",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.commodity_rate_units,
+            desc=f"{self.commodity} input and output from storage",
+        )
+        self.add_output(
+            f"storage_{self.commodity}_discharge",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.commodity_rate_units,
+            desc=f"{self.commodity} output from storage only",
+        )
+
+        self.add_output(
+            f"storage_{self.commodity}_charge",
+            val=0.0,
+            shape=self.n_timesteps,
+            units=self.commodity_rate_units,
+            desc=f"{self.commodity} input to storage only",
+        )
+        self.add_output(
+            "SOC",
+            val=0.0,
+            shape=self.n_timesteps,
+            units="percent",
+            desc="State of charge of storage",
         )
 
         self.dt_hr = int(self.options["plant_config"]["plant"]["simulation"]["dt"]) / (
@@ -117,7 +237,12 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
         # Step 1: Auto-size the storage to meet the demand
 
         # Auto-size the fill rate as the max of the input commodity
-        storage_max_fill_rate = np.max(inputs[f"{self.commodity}_in"])
+        storage_max_fill_rate = (
+            np.max(inputs[f"{self.commodity}_in"]) / self.config.charge_efficiency
+        )
+        storage_max_unfill_rate = (
+            np.max(inputs[f"{self.commodity}_in"]) / self.config.discharge_efficiency
+        )
 
         # Set the demand profile
         if np.sum(inputs[f"{self.commodity}_demand"]) > 0:
@@ -129,19 +254,14 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
                 self.n_timesteps
             )  # TODO: update demand based on end-use needs
 
-        # The commodity_set_point is the production set by the controller
-        # storage_dispatch_commands = inputs[f"{self.commodity}_set_point"]
-
         # TODO: SOC is just an absolute value and is not a percentage. Ideally would calculate as shortfall in future.
         # Size the storage capacity to meet the demand as much as possible
-        commodity_storage_soc = []
+        commodity_storage_soc = np.zeros(self.n_timesteps)
         for j in range(len(inputs[f"{self.commodity}_in"])):
             if j == 0:
-                commodity_storage_soc.append(
-                    inputs[f"{self.commodity}_in"][j] - commodity_demand[j]
-                )
+                commodity_storage_soc[j] = inputs[f"{self.commodity}_in"][j] - commodity_demand[j]
             else:
-                commodity_storage_soc.append(
+                commodity_storage_soc[j] = (
                     commodity_storage_soc[j - 1]
                     + inputs[f"{self.commodity}_in"][j]
                     - commodity_demand[j]
@@ -150,19 +270,30 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
         minimum_soc = np.min(commodity_storage_soc)
 
         # Adjust soc so it's not negative.
-        if minimum_soc < 0:
-            commodity_storage_soc = [x + np.abs(minimum_soc) for x in commodity_storage_soc]
+        if np.min(commodity_storage_soc) < 0:
+            commodity_storage_soc = np.abs(minimum_soc) + commodity_storage_soc
+            # commodity_storage_soc = [x + np.abs(minimum_soc) for x in commodity_storage_soc]
 
         # Calculate the maximum hydrogen storage capacity needed to meet the demand
-        commodity_storage_capacity = np.max(commodity_storage_soc) - np.min(commodity_storage_soc)
+        commodity_storage_capacity_max = np.max(commodity_storage_soc) - np.min(
+            commodity_storage_soc
+        )
+
+        # Increase capacity to adjust for min and max SOC bounds
+        commodity_storage_capacity = commodity_storage_capacity_max / (
+            self.config.max_charge_fraction - self.config.min_charge_fraction
+        )
 
         # Step 2: Simulate the storage performance based on the sizes calculated
-        self.current_soc = commodity_storage_soc[0] / commodity_storage_capacity
+        # Initialize the starting SOC
+        self.current_soc = np.max(
+            [commodity_storage_soc[0] / commodity_storage_capacity, self.config.min_charge_fraction]
+        )
 
         storage_commodity_out, soc = self.simulate(
             storage_dispatch_commands=inputs[f"{self.commodity}_set_point"],
             charge_rate=storage_max_fill_rate,
-            discharge_rate=storage_max_fill_rate,
+            discharge_rate=storage_max_unfill_rate,
             storage_capacity=commodity_storage_capacity,
         )
 
@@ -179,39 +310,49 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
         total_commodity_out = np.minimum(commodity_demand, combined_commodity_out)
 
         # determine how much of the inflow commodity was unused
-        # unused_commodity = np.maximum(
-        #     0, combined_commodity_out - inputs[f"{self.commodity}_demand"]
-        # )
+        unused_commodity = np.maximum(
+            0, combined_commodity_out - inputs[f"{self.commodity}_demand"]
+        )
 
-        # # determine how much demand was not met
-        # unmet_demand = np.maximum(
-        #     0, inputs[f"{self.commodity}_demand"] - combined_commodity_out
-        # )
+        # determine how much demand was not met
+        unmet_demand = np.maximum(0, inputs[f"{self.commodity}_demand"] - combined_commodity_out)
 
-        discharge_storage = np.where(storage_commodity_out > 0, storage_commodity_out, 0)
+        # Output the storage performance timeseries
+        outputs[f"storage_{self.commodity}_charge"] = np.where(
+            storage_commodity_out < 0, storage_commodity_out, 0
+        )
+        outputs[f"storage_{self.commodity}_discharge"] = np.where(
+            storage_commodity_out > 0, storage_commodity_out, 0
+        )
+
+        outputs[f"unmet_{self.commodity}_demand_out"] = unmet_demand
+        outputs[f"unused_{self.commodity}_out"] = unused_commodity
+        outputs[f"storage_{self.commodity}_out"] = storage_commodity_out
 
         # Output the storage sizes (charge rate and capacity)
         outputs["max_charge_rate"] = storage_max_fill_rate
         outputs["max_capacity"] = commodity_storage_capacity
+        if "max_discharge_rate" in outputs:
+            outputs["max_discharge_rate"] = storage_max_unfill_rate
 
         # commodity_out is the commodity_set_point - charge_storage + discharge_storage
         outputs[f"{self.commodity}_out"] = total_commodity_out
 
         # The rated_commodity_production is based on the discharge rate
-        # (which is assumed equal to the charge rate)
-        outputs[f"rated_{self.commodity}_production"] = storage_max_fill_rate
+        outputs[f"rated_{self.commodity}_production"] = storage_max_unfill_rate
 
         # The total_commodity_produced is the sum of the commodity discharged from storage
-        outputs[f"total_{self.commodity}_produced"] = discharge_storage.sum()
+        outputs[f"total_{self.commodity}_produced"] = np.sum(total_commodity_out)
+
         # Adjust the total_commodity_produced to a year-long simulation
         outputs[f"annual_{self.commodity}_produced"] = outputs[
             f"total_{self.commodity}_produced"
         ] * (1 / self.fraction_of_year_simulated)
 
         # The maximum production is based on the charge/discharge rate
-        max_production = storage_max_fill_rate * self.n_timesteps * (self.dt / 3600)
+        max_production = storage_max_unfill_rate * self.n_timesteps * (self.dt / 3600)
 
-        # Capacity factor is total discharged commodity / maximum discharged commodity possible
+        # Capacity factor is total commodity produced / maximum discharged commodity possible
         outputs["capacity_factor"] = outputs[f"total_{self.commodity}_produced"] / max_production
 
     def simulate(
@@ -285,10 +426,10 @@ class StorageAutoSizingModel(PerformanceModelBaseClass):
 
         # Pre-compute scalar constants to avoid repeated attribute lookups
         # and redundant divisions inside the per-timestep loop.
-        charge_eff = 1.0
-        discharge_eff = 1.0
-        soc_max = 1.0
-        soc_min = 0.0
+        charge_eff = self.config.charge_efficiency
+        discharge_eff = self.config.discharge_efficiency
+        soc_max = self.config.max_charge_fraction
+        soc_min = self.config.min_charge_fraction
 
         # max_charge_input / max_discharge_input are the hardware rate limits
         # expressed in *pre-efficiency* rate units so they can be compared

--- a/h2integrate/storage/test/test_simple_generic_storage.py
+++ b/h2integrate/storage/test/test_simple_generic_storage.py
@@ -1,0 +1,271 @@
+import numpy as np
+import pytest
+import openmdao.api as om
+from pytest import fixture
+
+from h2integrate.storage.simple_generic_storage import SimpleGenericStorage
+
+
+@fixture
+def performance_model_config(
+    charge_eff, discharge_eff, roundtrip_eff, soc_min, soc_max, discharge_rate, demand_profile
+):
+    storage_config = {
+        "commodity": "hydrogen",
+        "commodity_rate_units": "kg/h",
+        "max_charge_rate": 10.0,
+        "max_capacity": 40.0,
+        "max_charge_fraction": soc_max,
+        "min_charge_fraction": soc_min,
+        "init_charge_fraction": 0.1,
+        "commodity_amount_units": "kg",
+        "max_discharge_rate": discharge_rate,
+        "charge_equals_discharge": True,
+        "charge_efficiency": charge_eff,
+        "discharge_efficiency": discharge_eff,
+        "round_trip_efficiency": roundtrip_eff,
+        "demand_profile": demand_profile,
+    }
+
+    if discharge_rate != storage_config["max_charge_rate"]:
+        storage_config["charge_equals_discharge"] = False
+
+    return storage_config
+
+
+@fixture
+def plant_config():
+    plant = {
+        "plant": {
+            "plant_life": 30,
+            "simulation": {
+                "dt": 3600,
+                "n_timesteps": 24,
+            },
+        },
+    }
+    return plant
+
+
+@fixture
+def expected_profiles(case_name, discharge_eff, roundtrip_eff):
+    match case_name:
+        case "charge>demand":
+            expected_charge = np.concat([np.zeros(8), np.arange(-1, -9, -1), np.zeros(8)])
+            expected_discharge = np.concat([np.zeros(18), np.ones(6)])
+
+        case "charge<demand":
+            expected_charge = np.concat(
+                [np.full(3, -9), np.zeros(11), np.arange(-1, -5, -1), np.zeros(6)]
+            )
+            expected_discharge = np.concat(
+                [np.zeros(3), np.array([10, 9, 8]), np.zeros(12), np.array([7, 3]), np.zeros(4)]
+            )
+
+        case "losses":
+            expected_charge = np.concat(
+                [np.zeros(8), np.arange(-0.8, -7.2, -0.8), np.array([-5.76, -1.152]), np.zeros(6)]
+            )
+            expected_discharge = np.concat([np.zeros(18), discharge_eff * np.ones(6)])
+
+        case "roundtrip_losses":
+            expected_charge = np.concat(
+                [
+                    np.zeros(8),
+                    np.arange(
+                        -1 * np.sqrt(roundtrip_eff),
+                        -6.5,
+                        -np.sqrt(roundtrip_eff),
+                    ),
+                    np.array([-6.28548009, -1.41676815]),
+                    np.zeros(6),
+                ]
+            )
+            expected_discharge = np.concat([np.zeros(18), np.sqrt(roundtrip_eff) * np.ones(6)])
+
+    return (expected_charge, expected_discharge)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "case_name,charge_eff,discharge_eff,roundtrip_eff,soc_min,soc_max,discharge_rate,demand_profile",
+    [
+        ("charge>demand", 1.0, 1.0, None, 0.1, 1.0, 10.0, 5.0),
+        ("charge<demand", 1.0, 1.0, None, 0.1, 1.0, 10.0, 11.0),
+        ("losses", 0.8, 0.75, None, 0.1, 1.0, 10.0, 5.0),
+        ("roundtrip_losses", None, None, 0.6, 0.1, 1.0, 10.0, 5.0),
+    ],
+    ids=["charge>demand", "charge<demand", "losses", "roundtrip_losses"],
+)
+def test_no_controller_charge_equals_discharge(
+    plant_config, performance_model_config, expected_profiles, case_name, subtests
+):
+    expected_charge, expected_discharge = expected_profiles
+
+    commodity_demand = np.full(24, performance_model_config["demand_profile"])
+
+    cases_start_with_zero_in = ["losses", "charge>demand", "roundtrip_losses"]
+    if case_name in cases_start_with_zero_in:
+        commodity_in = np.concat([np.zeros(3), np.cumsum(np.ones(15)), np.full(6, 4.0)])
+    else:
+        commodity_in = np.concat([np.full(3, 20.0), np.cumsum(np.ones(15)), np.full(6, 4.0)])
+
+    prob = om.Problem()
+
+    commodity_set_point = commodity_demand - commodity_in
+
+    prob.model.add_subsystem(
+        name="IVC1",
+        subsys=om.IndepVarComp(name="hydrogen_in", val=commodity_in, units="kg/h"),
+        promotes=["*"],
+    )
+
+    prob.model.add_subsystem(
+        name="IVC2",
+        subsys=om.IndepVarComp(name="hydrogen_demand", val=commodity_demand, units="kg/h"),
+        promotes=["*"],
+    )
+
+    prob.model.add_subsystem(
+        name="IVC3",
+        subsys=om.IndepVarComp(name="hydrogen_set_point", val=commodity_set_point, units="kg/h"),
+        promotes=["*"],
+    )
+
+    prob.model.add_subsystem(
+        "storage",
+        SimpleGenericStorage(
+            plant_config=plant_config,
+            tech_config={"model_inputs": {"performance_parameters": performance_model_config}},
+        ),
+        promotes=["*"],
+    )
+
+    prob.setup()
+
+    prob.run_model()
+
+    charge_rate = prob.get_val("storage.max_charge_rate", units="kg/h")[0]
+    discharge_rate = prob.get_val("storage.max_charge_rate", units="kg/h")[0]
+    capacity = prob.get_val("storage.storage_capacity", units="kg")[0]
+
+    with subtests.test("Charge rate = charge rate from config"):
+        assert pytest.approx(charge_rate, rel=1e-6) == performance_model_config["max_charge_rate"]
+    with subtests.test("Capacity = capacity from config"):
+        assert pytest.approx(capacity, rel=1e-6) == performance_model_config["max_capacity"]
+
+    # Test that discharge is always positive
+    with subtests.test("Discharge is always positive"):
+        assert np.all(prob.get_val("storage.storage_hydrogen_discharge", units="kg/h") >= 0)
+
+    with subtests.test("Charge is always negative"):
+        assert np.all(prob.get_val("storage.storage_hydrogen_charge", units="kg/h") <= 0)
+
+    with subtests.test("Charge + Discharge == storage_hydrogen_out"):
+        charge_plus_discharge = prob.get_val(
+            "storage.storage_hydrogen_charge", units="kg/h"
+        ) + prob.get_val("storage.storage_hydrogen_discharge", units="kg/h")
+        np.testing.assert_allclose(
+            charge_plus_discharge, prob.get_val("storage_hydrogen_out", units="kg/h"), rtol=1e-6
+        )
+    with subtests.test("Initial SOC is correct"):
+        init_soc_expected = (
+            performance_model_config["init_charge_fraction"]
+            - prob.get_val("storage_hydrogen_out", units="kg/h")[0] / capacity
+        )
+        assert (
+            pytest.approx(prob.model.get_val("storage.SOC", units="unitless")[0], rel=1e-6)
+            == init_soc_expected
+        )
+
+    indx_soc_increase = np.argwhere(
+        np.diff(prob.model.get_val("storage.SOC", units="unitless"), prepend=True) > 0
+    ).flatten()
+    indx_soc_decrease = np.argwhere(
+        np.diff(prob.model.get_val("storage.SOC", units="unitless"), prepend=False) < 0
+    ).flatten()
+    indx_soc_same = np.argwhere(
+        np.diff(prob.model.get_val("storage.SOC", units="unitless"), prepend=True) == 0.0
+    ).flatten()
+
+    with subtests.test("SOC increases when charging"):
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_charge", units="kg/h")[indx_soc_increase] < 0
+        )
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_charge", units="kg/h")[indx_soc_decrease] == 0
+        )
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_charge", units="kg/h")[indx_soc_same] == 0
+        )
+
+    with subtests.test("SOC decreases when discharging"):
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_discharge", units="kg/h")[indx_soc_decrease] > 0
+        )
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_discharge", units="kg/h")[indx_soc_increase] == 0
+        )
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_discharge", units="kg/h")[indx_soc_same] == 0
+        )
+
+    with subtests.test("Max SOC <= Max storage percent"):
+        assert (
+            prob.get_val("storage.SOC", units="unitless").max()
+            <= performance_model_config["max_charge_fraction"]
+        )
+
+    with subtests.test("Min SOC >= Min storage percent"):
+        assert (
+            prob.get_val("storage.SOC", units="unitless").min()
+            >= performance_model_config["min_charge_fraction"]
+        )
+
+    with subtests.test("Charge never exceeds charge rate"):
+        c_eff = (
+            performance_model_config["charge_efficiency"]
+            if performance_model_config.get("charge_efficiency", None) is not None
+            else np.sqrt(performance_model_config["round_trip_efficiency"])
+        )
+        assert (
+            prob.get_val("storage.storage_hydrogen_charge", units="kg/h").min()
+            >= -1 * charge_rate * c_eff
+        )
+
+    with subtests.test("Discharge never exceeds discharge rate"):
+        d_eff = (
+            performance_model_config["discharge_efficiency"]
+            if performance_model_config.get("discharge_efficiency", None) is not None
+            else np.sqrt(performance_model_config["round_trip_efficiency"])
+        )
+        assert (
+            prob.get_val("storage.storage_hydrogen_discharge", units="kg/h").max()
+            <= discharge_rate * d_eff
+        )
+
+    with subtests.test("Discharge never exceeds demand"):
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_discharge", units="kg/h").max()
+            <= commodity_demand
+        )
+
+    with subtests.test("Cumulative charge/discharge does not exceed storage capacity"):
+        assert np.cumsum(prob.get_val("storage_hydrogen_out", units="kg/h")).max() <= capacity
+        assert np.cumsum(prob.get_val("storage_hydrogen_out", units="kg/h")).min() >= -1 * capacity
+
+    with subtests.test("Expected discharge"):
+        np.testing.assert_allclose(
+            prob.get_val("storage.storage_hydrogen_discharge", units="kg/h"),
+            expected_discharge,
+            rtol=1e-6,
+            atol=1e-10,
+        )
+
+    with subtests.test("Expected charge"):
+        np.testing.assert_allclose(
+            prob.get_val("storage.storage_hydrogen_charge", units="kg/h"),
+            expected_charge,
+            rtol=1e-6,
+            atol=1e-10,
+        )

--- a/h2integrate/storage/test/test_storage_autosizing.py
+++ b/h2integrate/storage/test/test_storage_autosizing.py
@@ -1,0 +1,219 @@
+import numpy as np
+import pytest
+import openmdao.api as om
+from pytest import fixture
+
+from h2integrate.storage.simple_storage_auto_sizing import StorageAutoSizingModel
+
+
+@fixture
+def performance_model_config(
+    charge_eff, discharge_eff, roundtrip_eff, soc_min, soc_max, charge_equal_discharge
+):
+    storage_config = {
+        "commodity": "hydrogen",
+        "commodity_rate_units": "kg/h",
+        "max_charge_fraction": soc_max,
+        "min_charge_fraction": soc_min,
+        "commodity_amount_units": "kg",
+        "charge_equals_discharge": charge_equal_discharge,
+        "charge_efficiency": charge_eff,
+        "discharge_efficiency": discharge_eff,
+        "round_trip_efficiency": roundtrip_eff,
+        "demand_profile": 0.0,
+    }
+
+    return storage_config
+
+
+@fixture
+def plant_config():
+    plant = {
+        "plant": {
+            "plant_life": 30,
+            "simulation": {
+                "dt": 3600,
+                "n_timesteps": 24,
+            },
+        },
+    }
+    return plant
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "case_name,charge_eff,discharge_eff,roundtrip_eff,soc_min,soc_max,charge_equal_discharge",
+    [
+        ("original", 1.0, 1.0, None, 0.0, 1.0, True),
+        ("soc_limited", 1.0, 1.0, None, 0.2, 0.8, True),
+        ("charge_losses", 0.8, 0.75, None, 0.0, 1.0, True),
+        ("roundtrip_losses", None, None, 0.6, 0.0, 1.0, True),
+    ],
+    ids=["original", "soc_limited", "charge_losses", "roundtrip_losses"],
+)
+def test_no_controller_charge_equals_discharge(
+    plant_config, performance_model_config, case_name, subtests
+):
+    # expected_charge, expected_discharge = expected_profiles
+
+    # Get the charge and discharge profiles
+    c_eff = (
+        performance_model_config["charge_efficiency"]
+        if performance_model_config.get("charge_efficiency", None) is not None
+        else np.sqrt(performance_model_config["round_trip_efficiency"])
+    )
+    d_eff = (
+        performance_model_config["discharge_efficiency"]
+        if performance_model_config.get("discharge_efficiency", None) is not None
+        else np.sqrt(performance_model_config["round_trip_efficiency"])
+    )
+
+    commodity_in = np.concat([np.zeros(3), np.cumsum(np.ones(15)), np.full(6, 4.0)])
+
+    commodity_demand = np.full(24, np.mean(commodity_in))
+
+    prob = om.Problem()
+
+    commodity_set_point = commodity_demand - commodity_in
+
+    soc_unadjusted_kg = np.cumsum(commodity_in - commodity_demand)
+    if np.min(soc_unadjusted_kg) < 0:
+        soc_unadjusted_kg = np.abs(np.min(soc_unadjusted_kg)) + soc_unadjusted_kg
+
+    max_storage_capacity = (np.max(soc_unadjusted_kg) - np.min(soc_unadjusted_kg)) / (
+        performance_model_config["max_charge_fraction"]
+        - performance_model_config["min_charge_fraction"]
+    )
+    max_charge_rate = np.max(commodity_in)
+
+    prob.model.add_subsystem(
+        name="IVC1",
+        subsys=om.IndepVarComp(name="hydrogen_in", val=commodity_in, units="kg/h"),
+        promotes=["*"],
+    )
+
+    prob.model.add_subsystem(
+        name="IVC2",
+        subsys=om.IndepVarComp(name="hydrogen_demand", val=commodity_demand, units="kg/h"),
+        promotes=["*"],
+    )
+
+    prob.model.add_subsystem(
+        name="IVC3",
+        subsys=om.IndepVarComp(name="hydrogen_set_point", val=commodity_set_point, units="kg/h"),
+        promotes=["*"],
+    )
+
+    prob.model.add_subsystem(
+        "storage",
+        StorageAutoSizingModel(
+            plant_config=plant_config,
+            tech_config={"model_inputs": {"performance_parameters": performance_model_config}},
+        ),
+        promotes=["*"],
+    )
+
+    prob.setup()
+
+    prob.run_model()
+
+    charge_rate = prob.get_val("storage.max_charge_rate", units="kg/h")[0]
+    discharge_rate = prob.get_val("storage.max_charge_rate", units="kg/h")[0]
+    capacity = prob.get_val("storage.max_capacity", units="kg")[0]
+
+    with subtests.test("Charge rate = charge rate from config"):
+        assert pytest.approx(charge_rate, rel=1e-6) == max_charge_rate / c_eff
+    with subtests.test("Capacity = capacity from config"):
+        assert pytest.approx(capacity, rel=1e-6) == max_storage_capacity
+
+    # Test that discharge is always positive
+    with subtests.test("Discharge is always positive"):
+        assert np.all(prob.get_val("storage.storage_hydrogen_discharge", units="kg/h") >= 0)
+
+    with subtests.test("Charge is always negative"):
+        assert np.all(prob.get_val("storage.storage_hydrogen_charge", units="kg/h") <= 0)
+
+    with subtests.test("Charge + Discharge == storage_hydrogen_out"):
+        charge_plus_discharge = prob.get_val(
+            "storage.storage_hydrogen_charge", units="kg/h"
+        ) + prob.get_val("storage.storage_hydrogen_discharge", units="kg/h")
+        np.testing.assert_allclose(
+            charge_plus_discharge, prob.get_val("storage_hydrogen_out", units="kg/h"), rtol=1e-6
+        )
+
+    indx_soc_increase = np.argwhere(
+        np.diff(prob.model.get_val("storage.SOC", units="unitless"), prepend=True) > 0
+    ).flatten()
+    indx_soc_decrease = np.argwhere(
+        np.diff(prob.model.get_val("storage.SOC", units="unitless"), prepend=False) < 0
+    ).flatten()
+    indx_soc_same = np.argwhere(
+        np.diff(prob.model.get_val("storage.SOC", units="unitless"), prepend=True) == 0.0
+    ).flatten()
+
+    with subtests.test("SOC increases when charging"):
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_charge", units="kg/h")[indx_soc_increase] < 0
+        )
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_charge", units="kg/h")[indx_soc_decrease] == 0
+        )
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_charge", units="kg/h")[indx_soc_same] == 0
+        )
+
+    with subtests.test("SOC decreases when discharging"):
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_discharge", units="kg/h")[indx_soc_decrease] > 0
+        )
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_discharge", units="kg/h")[indx_soc_increase] == 0
+        )
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_discharge", units="kg/h")[indx_soc_same] == 0
+        )
+
+    with subtests.test("Max SOC <= Max storage percent"):
+        assert (
+            prob.get_val("storage.SOC", units="unitless").max()
+            <= performance_model_config["max_charge_fraction"]
+        )
+
+    with subtests.test("Min SOC >= Min storage percent"):
+        assert (
+            prob.get_val("storage.SOC", units="unitless").min()
+            >= performance_model_config["min_charge_fraction"]
+        )
+
+    with subtests.test("Charge never exceeds charge rate"):
+        assert (
+            prob.get_val("storage.storage_hydrogen_charge", units="kg/h").min()
+            >= -1 * charge_rate * c_eff
+        )
+
+    with subtests.test("Discharge never exceeds discharge rate"):
+        assert (
+            prob.get_val("storage.storage_hydrogen_discharge", units="kg/h").max()
+            <= discharge_rate * d_eff
+        )
+
+    with subtests.test("Discharge never exceeds demand"):
+        assert np.all(
+            prob.get_val("storage.storage_hydrogen_discharge", units="kg/h").max()
+            <= commodity_demand
+        )
+
+    with subtests.test("Cumulative charge/discharge does not exceed storage capacity"):
+        assert np.cumsum(prob.get_val("storage_hydrogen_out", units="kg/h")).max() <= capacity
+        assert np.cumsum(prob.get_val("storage_hydrogen_out", units="kg/h")).min() >= -1 * capacity
+
+    with subtests.test("Expected unmet demand"):
+        expected_unmet_demand = np.maximum(
+            0, commodity_demand - (commodity_in + charge_plus_discharge)
+        )
+        np.testing.assert_allclose(
+            prob.model.get_val("storage.unmet_hydrogen_demand_out", units="kg/h"),
+            expected_unmet_demand,
+            rtol=1e-6,
+            atol=1e-10,
+        )


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELETE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code highlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Sync open-loop controllers and corresponding storage models
<!-- Describe your feature here. Please include any code snippets or examples in this section. -->

**This PR is slight on-hold until we:**
1. Add in tests for the Demand Open Loop Controller with <1 charge and discharge efficiencies
2. Update the generic storage Pyomo model to correctly account for charge/discharge efficiencies (PR #600) and add subtests.

**But high-level feedback (listed in Section 2 under the "Type of Reviewer Feedback Requested" section) is still appreciated at this time.**

The main changes in this PR are:
- standardized definition of `commodity_set_point` of the two open-loop storage controllers and their corresponding storage performance models (Resolves Issue #498)
- sync up the workflow of the storage performance models that are used with the open-loop storage controllers to better align with the storage performance models that are used with pyomo controllers
- begin to standardize inputs and outputs of open-loop controllers and storage models

This PR helps standardize what calculations and outputs are done by the controllers vs what calculations and outputs are done in the storage performance models. In summary, outputs are:
- Open-loop controllers compute and output the `commodity_set_point`, which is equivalent to the `storage_commodity_out` output of the `pyomo_disapatch_solver` method in the pyomo controllers (input to the `simulate` method of the storage models as `storage_dispatch_commands`). The `commodity_set_point` is the control command telling the storage to charge (negative values) or discharge (positive values)
- Storage performance models output the SOC, unmet demand, excess commodity, the output from the storage only (similar to `commodity_set_point` but may differ if the storage performance model has losses or degradation) and the combined commodity out (input - charge + discharge then saturated to the demand). 


Note: this PR changed some output names for the open-loop controllers (to align with the output names in the storage models that use pyomo controllers). User's may have to update any examples that use H2I. Examples of the name changes are:
- `battery.electricity_unused_commodity` -> `battery.unused_electricity_out`
- `battery.electricity_unmet_demand` -> `battery.unmet_electricity_demand_out`
- `battery.battery_soc` -> `battery.SOC`


The planned next-step of this work is to:
- integrate the use of open-loop controllers with the storage models that only use pyomo controllers (pysam battery and generic storage)
- integrate the use of pyomo controllers with the storage models that only use open loop controllers
- make a storage performance model baseclass and baseconfig that can be inherited by all storage performance models
- make an open loop storage controller baseclass that can be shared with the pass-through open loop controller and the demand open loop controller



## Section 1: Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [ ] Feature Enhancement
  - [ ] Framework
  - [ ] New Model
  - [x] Updated Model
  - [ ] Tools/Utilities
  - [ ] Other (please describe):
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## Section 2: Draft PR Checklist
<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
<!--Complete when opening a draft PR. -->
- [x] Open draft PR
- [x] Describe the feature that will be added
- [x] Fill out TODO list steps
- [ ] Describe requested feedback from reviewers on draft PR
- [ ] Complete Section 7: New Model Checklist (if applicable)
<!-- Describe the feature in this PR and outline next steps -->

### TODO:
- [x] Fix the `setup_partials()` method of the `PassThroughOpenLoopController` (can someone help me with this?)
- [x] Remove outputs from the open-loop controllers that should be outputs of the storage performance models
- [x] Sync up the inputs and configuration classes for the open-loop controllers and the storage performance models 
- [x] Clean up inline comments and docstrings
- [x] Sync the variable names in the open loop controllers
- [x] Sync the variable names and workflow in the storage performance models
- [x] Fix docs build
- [ ] add subtests for additional storage outputs/capabilities in `StorageAutoSizingModel`
   - [ ] add subtest for storage auto-sizing if min/max soc are not 0 and 1
   - [ ] add subtest for storage auto-sizing if charge and discharge efficiency are not 1.0
 - [ ] add doc strings to `PassThroughOpenLoopControllerConfig` and `SimpleGenericStorageConfig`
 - [ ] update docstrings where needed
 - [ ] update output name of "max_capacity" to "storage_capacity" in `StorageAutoSizingModel`
 - [ ] move necessary inputs under control_parameters to shared_parameters in any examples that use the `DemandOpenLoopStorageController`

### Type of Reviewer Feedback Requested (on Draft PR)
<!-- Outline the feedback that would be helpful from reviewers while it's a draft PR -->

**High-level feedback**:
- Thoughts on how the controller outputs interface with the storage model inputs in this PR? And how some calculations that were done in the controllers are now done in the storage performance models?
- Thoughts on the updated naming convention for things like unmet demand, excess commodity, etc?

**Structural feedback**:
- should I create a baseclass for the `PassThroughOpenLoopController` and `DemandOpenLoopStorageController` in this PR? This could wait until a follow-on PR
- I think the file `h2integrate/control/control_strategies/passthrough_openloop_controller.py` should be moved to `h2integrate/control/control_strategies/storage/passthrough_openloop_controller.py`. Thoughts?
- With the changes in this PR, the `DemandOpenLoopControlBase` (in file `h2integrate/control/control_strategies/demand_openloop_controller.py`) is only inherited by `DemandOpenLoopConverterController` (in file `h2integrate/control/control_strategies/converters/demand_openloop_controller.py`). Should I remove the `DemandOpenLoopControlBase` and update the `DemandOpenLoopConverterController`?
**Implementation feedback**:

**Other feedback**:
- @jaredthomas68, I'd like you thoughts on the failing subtests for Example 29 (see Section 6 for more information). I can't run Example 29 locally so I can't dig into it deeper than following the failed subtests and assuming that my reasoning is right. If you'd want to dig into this together, I'd be happy to hop on a call.

## Section 3: General PR Checklist
<!--Complete when converting draft PR to a merge-ready PR. -->
- [ ] PR description thoroughly describes the new feature, bug fix, etc.
- [ ] Added tests for new functionality or bug fixes
- [ ] Tests pass (If not, and this is expected, please elaborate in the Section 6: Test Results)
- [ ] Documentation
  - [ ] Docstrings are up-to-date
  - [ ] Related `docs/` files are up-to-date, or added when necessary
  - [ ] Documentation has been rebuilt successfully
  - [ ] Examples have been updated (if applicable)
- [ ] `CHANGELOG.md` has been updated to describe the changes made in this PR

## Section 3: Related Issues
<!--If this PR relates to an existing GitHub issue, please link the issue and indicate whether this PR would fully or partially resolve that issue. Please also link any issues that were created due to this PR-->

- Resolves Issue #498 and Issue #566 (which is a step in Issue #564)
- Related to (but does not resolve) Issue #566 

## Section 4: Impacted Areas of the Software
<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why. Can exclude CHANGELOG.md, doc pages and supported_models.py.
-->
### Section 4.1: New Files
- `h2integrate/storage/test/test_simple_generic_storage.py`: new unit and regression tests for `SimpleGenericStorage`
- `h2integrate/storage/test/test_storage_autosizing.py`: new unit and regression tests for `StorageAutoSizingModel`

### Section 4.2: Modified Files
#### Primary modified files
- `h2integrate/storage/simple_generic_storage.py`
   - `SimpleGenericStorageConfig`
   - `SimpleGenericStorage`
      - added outputs to align with other storage performance models, such as `unmet_{commodity}_demand_out`, `unused_{commodity}_out`, `SOC`, `storage_{commodity}_discharge`, `storage_{commodity}_charge`, and `storage_{commodity}_out`.
      - added `storage_duration` as an output
- `h2integrate/storage/simple_storage_auto_sizing.py`
   - `StorageSizingModelConfig`
      - added inputs to align with other storage performance models, such as ....
   - `StorageAutoSizingModel`
      - added outputs to align with other storage performance models, such as `unmet_{commodity}_demand_out`, `unused_{commodity}_out`, `SOC`, `storage_{commodity}_discharge`, `storage_{commodity}_charge`, and `storage_{commodity}_out`.
      - added `storage_duration` as an output
- `h2integrate/control/control_strategies/storage/demand_openloop_controller.py`
   - `DemandOpenLoopStorageControllerConfig`
      - no longer inherits `DemandOpenLoopControlBaseConfig`
      - updated `__attrs_post_init__()` method to align with the one in `StoragePerformanceModelConfig`
   - `DemandOpenLoopStorageController`
      - no longer inherits the `DemandOpenLoopControlBase`
      - removed outputs that are calculated in the storage performance models. Specifically, removed the outputs of `{commodity}_unmet_demand`, `{commodity}_unused_commodity`, `{commodity}_soc`, and `storage_duration`
- `h2integrate/control/control_strategies/passthrough_openloop_controller.py`
   - `PassThroughOpenLoopControllerConfig`
   - `PassThroughOpenLoopController`


#### Other modified files
- `docs/control/controller_demonstrations.md`: updated variable names to updated naming convention for open-loop controllers and storage models
- `h2integrate/control/test/test_openloop_controllers.py`: updated variable names to updated naming convention for open-loop controllers and storage models, added use of `SimpleGenericStorage` in some tests since some outputs were removed from the `DemandOpenLoopStorageController`

 
## Section 5: Additional Supporting Information
<!--Add any other context about the problem here.-->


## Section 6: Test Results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->

Some subtests are failing for `examples/test/test_all_examples.py::test_windard_pv_battery_dispatch_example`, which tests example 29. Example 29 uses the `DemandOpenLoopStorageController` with the `SimpleGenericStorage` performance model for the battery. This controller and model pairing is also used in Example 3, 14, 16, 19, and 24, which did not have changed test values. These other examples set the battery charge and discharge efficiency to 1.0, whereas example 29 has a charge and discharge efficiency of 0.985. Before this PR, the storage/controllers did not properly account for the charge efficiency, because the storage was basically a pass through component and the demand open-loop controller didn't include charge efficiency in its calculations. Now that the charge efficiency is included in the storage performance model, it'd be expected that less of the demand is met.

The subtests that failed were
- "Check demand satisfaction": the 30 MW demand is no longer fully met for the last 60 hours of the simulation. Now, in some hours, only 29.855 or 29.789 MW of the demand are met. This is because the storage is now accounting for both the charge and discharge efficiencies whereas before it was really only accounting for the discharge efficiency in the controller. 
- "Check dispatched LCOE value": LCOE increased to 0.093 USD/kWh from 0.0928 USD/kWh. LCOE increased because the battery capacity factor decreased because of including the charge/discharge efficiencies.
- "Check electricity curtailed": increased to 21059.693 MW from 20344.9 MW. Less demand met means more curtailed electricity.
- "Check electricity missed load": increased to 1403.656 MW from 1403.53 MW. Less demand met means more missed load.


The `DemandOpenLoopStorageController` used to output the combined input commodity and commodity output from the battery capped at the demand. Briefly, this is what it USED to do: (not done)
```python
if demand_t > input_flow:
   discharge_needed = (demand_t - input_flow) / discharge_efficiency
   discharge = min(discharge_needed, available_discharge, max_discharge_rate / discharge_efficiency)
   total_output_array[t] = input_flow + discharge * discharge_efficiency
else:
   unused_input = input_flow - demand_t
```

## Section 7 (Optional): New Model Checklist
<!-- Complete this section only if you checked "New Model" above -->
- [ ] **Model Structure**:
  - [ ] Follows established naming conventions outlined in `docs/developer_guide/coding_guidelines.md`
  - [ ] Used `attrs` class to define the `Config` to load in attributes for the model
    - [ ] If applicable: inherit from `BaseConfig` or `CostModelBaseConfig`
  - [ ] Added: `initialize()` method, `setup()` method, `compute()` method
    - [ ] If applicable: inherit from `CostModelBaseClass`
- [ ] **Integration**: Model has been properly integrated into H2Integrate
  - [ ] Added to `supported_models.py`
  - [ ] If a new commodity_type is added, update `create_financial_model` in `h2integrate_model.py`
- [ ] **Tests**: Unit tests have been added for the new model
  - [ ] [Pytest-style unit tests](https://realpython.com/pytest-python-testing/)
  - [ ] Unit tests are in a "test" folder within the folder a new model was added to
  - [ ] If applicable add integration tests
- [ ] **Example**: If applicable, a working example demonstrating the new model has been created
  - [ ] Input file comments
  - [ ] Run file comments
  - [ ] Example has been tested and runs successfully in `test_all_examples.py`
- [ ] **Documentation**:
  - [ ] Write docstrings using the [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
  - [ ] Model added to the main models list in `docs/user_guide/model_overview.md`
    - [ ] Model documentation page added to the appropriate `docs/` section
    - [ ] `<model_name>.md` is added to the `_toc.yml`





<!--
__ For NREL use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NREL/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
