### PR TITLE
Fixing OM 3.43 related bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Reorganized utilities, split them out to appropriate modules [PR 586](https://github.com/NatLabRockies/H2Integrate/pull/586)
 - Added a generic storage model that is compatible with the Pyomo controllers [PR 571](https://github.com/NatLabRockies/H2Integrate/pull/571)
 - Fixed a bug within the H2 storage cost models that used max rate instead of average for H2 flows [PR 588](https://github.com/NatLabRockies/H2Integrate/pull/588)
+- Fixed a bug in the discrete variable instantiation within the iron processing stack that caused a failure with OpenMDAO v3.43 [PR 595](https://github.com/NatLabRockies/H2Integrate/pull/595)
 
 ## 0.7 [March 3, 2026]
 

--- a/h2integrate/converters/iron/iron_mine.py
+++ b/h2integrate/converters/iron/iron_mine.py
@@ -70,7 +70,7 @@ class IronMinePerformanceComponent(om.ExplicitComponent):
             additional_cls_name=self.__class__.__name__,
         )
         self.add_discrete_output(
-            "iron_mine_performance", val=pd.DataFrame, desc="iron mine performance results"
+            "iron_mine_performance", val=pd.DataFrame(), desc="iron mine performance results"
         )
         self.add_output("iron_ore_out", val=0.0, shape=n_timesteps, units="kg/h")
         self.add_output("total_iron_ore_produced", val=0.0, units="t/year")
@@ -146,9 +146,11 @@ class IronMineCostComponent(CostModelBaseClass):
         self.add_input("LCOH", val=self.config.LCOH, units="USD/kg")
         self.add_input("total_iron_ore_produced", val=1.0, units="t/year")
         self.add_discrete_input(
-            "iron_mine_performance", val=pd.DataFrame, desc="iron mine performance results"
+            "iron_mine_performance", val=pd.DataFrame(), desc="iron mine performance results"
         )
-        self.add_discrete_output("iron_mine_cost", val=pd.DataFrame, desc="iron mine cost results")
+        self.add_discrete_output(
+            "iron_mine_cost", val=pd.DataFrame(), desc="iron mine cost results"
+        )
 
     def compute(self, inputs, outputs, discrete_inputs, discrete_outputs):
         ore_performance = IronPerformanceModelOutputs(

--- a/h2integrate/converters/iron/iron_plant.py
+++ b/h2integrate/converters/iron/iron_plant.py
@@ -70,7 +70,7 @@ class IronPlantPerformanceComponent(om.ExplicitComponent):
         )
         self.add_input("iron_ore_in", val=0.0, shape=n_timesteps, units="t/h")
         self.add_discrete_output(
-            "iron_plant_performance", val=pd.DataFrame, desc="iron plant performance results"
+            "iron_plant_performance", val=pd.DataFrame(), desc="iron plant performance results"
         )
         self.add_output("pig_iron_out", val=0.0, shape=n_timesteps, units="kg/h")
         self.add_output("total_pig_iron_produced", val=0.0, units="t/year")
@@ -155,10 +155,10 @@ class IronPlantCostComponent(CostModelBaseClass):
         self.add_input("ore_profit_pct", val=self.config.ore_profit_pct, units="USD/t")
         self.add_input("total_pig_iron_produced", val=1.0, units="t/year")
         self.add_discrete_input(
-            "iron_plant_performance", val=pd.DataFrame, desc="iron plant performance results"
+            "iron_plant_performance", val=pd.DataFrame(), desc="iron plant performance results"
         )
         self.add_discrete_output(
-            "iron_plant_cost", val=pd.DataFrame, desc="iron plant cost results"
+            "iron_plant_cost", val=pd.DataFrame(), desc="iron plant cost results"
         )
 
     def compute(self, inputs, outputs, discrete_inputs, discrete_outputs):

--- a/h2integrate/converters/steel/electric_arc_furnance.py
+++ b/h2integrate/converters/steel/electric_arc_furnance.py
@@ -62,7 +62,7 @@ class EAFPlantPerformanceComponent(om.ExplicitComponent):
         )
 
         self.add_discrete_output(
-            "steel_plant_performance", val=pd.DataFrame, desc="steel plant performance results"
+            "steel_plant_performance", val=pd.DataFrame(), desc="steel plant performance results"
         )
 
         self.add_output("total_steel_produced", val=0.0, units="t/year")
@@ -143,10 +143,10 @@ class EAFPlantCostComponent(CostModelBaseClass):
         self.add_input("iron_transport_cost", val=self.config.iron_transport_cost, units="USD/t")
         self.add_input("ore_profit_pct", val=self.config.ore_profit_pct, units="USD/t")
         self.add_discrete_input(
-            "steel_plant_performance", val=pd.DataFrame, desc="steel plant performance results"
+            "steel_plant_performance", val=pd.DataFrame(), desc="steel plant performance results"
         )
         self.add_discrete_output(
-            "steel_plant_cost", val=pd.DataFrame, desc="steel plant cost results"
+            "steel_plant_cost", val=pd.DataFrame(), desc="steel plant cost results"
         )
 
     def compute(self, inputs, outputs, discrete_inputs, discrete_outputs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "matplotlib",
   "numpy",
   "numpy-financial",
-  "openmdao<=3.42.0",
+  "openmdao",
   "openmeteo-requests",
   "pandas>=2.0.3",
   "ProFAST",


### PR DESCRIPTION
# Bugfix for OpenMDAO 3.43 release

We were instantiating discrete variables in our iron processing stack slightly incorrectly.
This worked properly in the past due to a lack of checks on the OpenMDAO side of things.
The newest OM version introduces more stringent checks.
I've updated the instantiation here to be correct -- use an _instance_ of the pandas `DataFrame` class instead of the class itself.
Of course I've also unpinned the priorly pinned OM version.

## Section 1: Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [ ] Feature Enhancement
  - [ ] Framework
  - [ ] New Model
  - [ ] Updated Model
  - [ ] Tools/Utilities
  - [ ] Other (please describe):
- [x] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):
