### PR TITLE
Bugfix when calling `check_inputs` when using round trip efficiency for storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Change commodity in DRI and EAF model from pig iron to sponge iron based on likely carbon content [PR 670](https://github.com/NatLabRockies/H2Integrate/pull/670)
+- Bugfix for round-trip efficiency handling when calling `check_inputs` around `StoragePerformanceModel` [PR 684](https://github.com/NatLabRockies/H2Integrate/pull/684)
 
 ## 0.8 [April 15, 2026]
 - Updated README and docs intro page with expanded H2I description, reorganized sections, and streamlined installation instructions [PR 677](https://github.com/NatLabRockies/H2Integrate/pull/677)

--- a/h2integrate/control/control_strategies/storage/demand_openloop_storage_controller.py
+++ b/h2integrate/control/control_strategies/storage/demand_openloop_storage_controller.py
@@ -83,7 +83,7 @@ class DemandOpenLoopStorageControllerConfig(StorageOpenLoopControlBaseConfig):
             # Calculate charge and discharge efficiencies from round-trip efficiency
             self.charge_efficiency = np.sqrt(self.round_trip_efficiency)
             self.discharge_efficiency = np.sqrt(self.round_trip_efficiency)
-            self.round_trip_efficiency = None
+
         if self.charge_efficiency is None or self.discharge_efficiency is None:
             raise ValueError(
                 "Exactly one of the following sets of parameters must be set: (a) "

--- a/h2integrate/storage/simple_storage_auto_sizing.py
+++ b/h2integrate/storage/simple_storage_auto_sizing.py
@@ -67,7 +67,7 @@ class StorageSizingModelConfig(StoragePerformanceBaseConfig):
             # Calculate charge and discharge efficiencies from round-trip efficiency
             self.charge_efficiency = np.sqrt(self.round_trip_efficiency)
             self.discharge_efficiency = np.sqrt(self.round_trip_efficiency)
-            self.round_trip_efficiency = None
+
         if self.charge_efficiency is None or self.discharge_efficiency is None:
             raise ValueError(
                 "Exactly one of the following sets of parameters must be set: (a) "

--- a/h2integrate/storage/storage_performance_model.py
+++ b/h2integrate/storage/storage_performance_model.py
@@ -83,7 +83,7 @@ class StoragePerformanceModelConfig(StoragePerformanceBaseConfig):
             # Calculate charge and discharge efficiencies from round-trip efficiency
             self.charge_efficiency = np.sqrt(self.round_trip_efficiency)
             self.discharge_efficiency = np.sqrt(self.round_trip_efficiency)
-            self.round_trip_efficiency = None
+
         if self.charge_efficiency is None or self.discharge_efficiency is None:
             raise ValueError(
                 "Exactly one of the following sets of parameters must be set: (a) "

--- a/h2integrate/storage/test/test_storage_performance_model.py
+++ b/h2integrate/storage/test/test_storage_performance_model.py
@@ -1023,3 +1023,35 @@ def test_generic_storage_with_simple_control_with_losses_round_trip(plant_config
             pytest.approx(2.5, rel=1e-6)
             == prob.get_val("storage.standard_capacity_factor", units="percent")[0]
         )
+
+
+@pytest.mark.unit
+def test_round_trip_efficiency_preserved_in_config(subtests):
+    """Test that round_trip_efficiency is preserved in the config's as_dict() output.
+
+    This is a regression test for a bug where round_trip_efficiency was set to None
+    after computing charge/discharge efficiencies in __attrs_post_init__. This caused
+    check_inputs() to raise an AttributeError because round_trip_efficiency appeared
+    in the user input but was missing from the config's as_dict() output.
+    """
+    from h2integrate.storage.storage_performance_model import StoragePerformanceModelConfig
+
+    round_trip_eff = 0.81
+
+    with subtests.test("StoragePerformanceModelConfig preserves round_trip_efficiency"):
+        config = StoragePerformanceModelConfig(
+            commodity="hydrogen",
+            commodity_rate_units="kg/h",
+            max_capacity=40,
+            max_charge_rate=10,
+            min_soc_fraction=0.1,
+            max_soc_fraction=1.0,
+            init_soc_fraction=0.5,
+            demand_profile=0.0,
+            round_trip_efficiency=round_trip_eff,
+        )
+        config_dict = config.as_dict()
+        assert "round_trip_efficiency" in config_dict
+        assert config_dict["round_trip_efficiency"] == round_trip_eff
+        assert config_dict["charge_efficiency"] == pytest.approx(np.sqrt(round_trip_eff))
+        assert config_dict["discharge_efficiency"] == pytest.approx(np.sqrt(round_trip_eff))


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELETE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code highlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Bugfix when calling check_inputs when using round trip efficiency for storage
<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
I was running a battery technology where I specified the round trip efficiency for the `StoragePerformanceModel` (instead of specifying the charge efficiency and discharge efficiency). The following error was raised from the `check_inputs()` function (in `h2integrate/core/dict_utils.py`) when I ran this technology:

```bash
AttributeError: The parameter(s) {'round_trip_efficiency'} found in performance_parameters are not used for the 'battery' section of None
```

This error arose because of the following line in the `__attrs_post_init__()` method in the `StoragePerformanceModelConfig`:
```python
if (self.round_trip_efficiency is not None) and (
    self.charge_efficiency is None and self.discharge_efficiency is None
):
    # Calculate charge and discharge efficiencies from round-trip efficiency
    self.charge_efficiency = np.sqrt(self.round_trip_efficiency)
    self.discharge_efficiency = np.sqrt(self.round_trip_efficiency)
    self.round_trip_efficiency = None # this line is why that error was raised!
```

A user can either specify the `charge_efficiency` and `discharge_efficiency` OR the `round_trip_efficiency`. If the user provides the `round_trip_efficiency`, the `charge_efficiency` and `discharge_efficiency` are both calculated as the square root of the `round_trip_efficiency`. The `self.round_trip_efficiency = None` line existed in the past to handle the logic this logic. That logic was updated and the `self.round_trip_efficiency = None` line is was no longer needed for handling the logic in the `__attrs_post_init__`, but remained. Anyway - I removed the same line in the `StorageSizingModelConfig` and `DemandOpenLoopStorageControllerConfig`.

This was not caught earlier because no tests run the `check_inputs()` method when the `round_trip_efficiency` is specified instead of `charge_efficiency` and `discharge_efficiency` for these models.

## Section 1: Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [ ] Feature Enhancement
  - [ ] Framework
  - [ ] New Model
  - [ ] Updated Model
  - [ ] Tools/Utilities
  - [ ] Other (please describe):
- [x] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## Section 2: Draft PR Checklist
<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
<!--Complete when opening a draft PR. -->
- [x] Open draft PR
- [x] Describe the feature that will be added
- [ ] Fill out TODO list steps
- [x] Describe requested feedback from reviewers on draft PR
- [ ] Complete Section 7: New Model Checklist (if applicable)
<!-- Describe the feature in this PR and outline next steps -->
### TODO:
- [ ] Step 1
- [ ] Step 2

### Type of Reviewer Feedback Requested (on Draft PR)
<!-- Outline the feedback that would be helpful from reviewers while it's a draft PR -->
**Structural feedback**:

**Implementation feedback**:
- would it make sense to add a subtest for this fix in the test_framework for this? Feels a bit weird since it was specific to only 3 models.

**Other feedback**:

## Section 3: General PR Checklist
<!--Complete when converting draft PR to a merge-ready PR. -->
- [x] PR description thoroughly describes the new feature, bug fix, etc.
- [ ] Added tests for new functionality or bug fixes
- [ ] Tests pass (If not, and this is expected, please elaborate in the Section 6: Test Results)
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [x] Examples have been updated (if applicable)
- [ ] `CHANGELOG.md`
  - [ ] At least one complete sentence has been provided to describe the changes made in this PR
  - [ ] After the above, a hyperlink has been provided to the PR using the following format:
    "A complete thought. [PR XYZ]((https://github.com/NatLabRockies/H2Integrate/pull/XYZ)", where
    `XYZ` should be replaced with the actual number.

## Section 4: Related Issues
<!--If this PR relates to an existing GitHub issue, please link the issue and indicate whether this PR would fully or partially resolve that issue. Please also link any issues that were created due to this PR-->


## Section 5: Impacted Areas of the Software
<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why. Can exclude CHANGELOG.md, doc pages and supported_models.py.
-->
### Section 5.1: New Files
- `path/to/file.extension`
  - `method1`: What and why something was changed in one sentence or less.

### Section 5.2: Modified Files

Explained in section 1

## Section 6: Additional Supporting Information
<!--Add any other context about the problem here.-->


## Section 7: Test Results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->

## Section 8 (Optional): New Model Checklist
<!-- Complete this section only if you checked "New Model" above -->
- [ ] **Model Structure**:
  - [ ] Follows established naming conventions outlined in `docs/developer_guide/coding_guidelines.md`
  - [ ] Used `attrs` class to define the `Config` to load in attributes for the model
    - [ ] If applicable: inherit from `BaseConfig` or `CostModelBaseConfig`
  - [ ] Added: `initialize()` method, `setup()` method, `compute()` method
    - [ ] If applicable: inherit from `CostModelBaseClass`
- [ ] **Integration**: Model has been properly integrated into H2Integrate
  - [ ] Added to `supported_models.py`
  - [ ] If a new commodity_type is added, update `create_financial_model` in `h2integrate_model.py`
- [ ] **Tests**: Unit tests have been added for the new model
  - [ ] [Pytest-style unit tests](https://realpython.com/pytest-python-testing/)
  - [ ] Unit tests are in a "test" folder within the folder a new model was added to
  - [ ] If applicable add integration tests
- [ ] **Example**: If applicable, a working example demonstrating the new model has been created
  - [ ] Input file comments
  - [ ] Run file comments
  - [ ] Example has been tested and runs successfully in `test_all_examples.py`
- [ ] **Documentation**:
  - [ ] Write docstrings using the [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
  - [ ] Model added to the main models list in `docs/user_guide/model_overview.md`
    - [ ] Model documentation page added to the appropriate `docs/` section
    - [ ] `<model_name>.md` is added to the `_toc.yml`
  - [ ] Run `generate_class_hierarchy.py` to update the class hierarchy diagram in `docs/developer_guide/class_structure.md`





<!--
__ For NLR use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NatLabRockies/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
