### PR TITLE
Ability to have a user-defined resource model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Added electricity and water consumption profiles as outputs to the `ECOElectrolyzerPerformanceModel` [PR 690](https://github.com/NatLabRockies/H2Integrate/pull/690)
 - Add `PeakLoadManagementHeuristicOpenLoopStorageController` as a storage control strategy. [PR 641](https://github.com/NatLabRockies/H2Integrate/pull/641)
 - Minor cleanup to `pose_optimization` [PR 695](https://github.com/NatLabRockies/H2Integrate/pull/695)
+- Added ability to have a custom/user-specified resource model [PR 698](https://github.com/NatLabRockies/H2Integrate/pull/698)
 
 ## 0.8 [April 15, 2026]
 - Updated README and docs intro page with expanded H2I description, reorganized sections, and streamlined installation instructions [PR 677](https://github.com/NatLabRockies/H2Integrate/pull/677)

--- a/docs/finance_models/finance_index.md
+++ b/docs/finance_models/finance_index.md
@@ -31,8 +31,7 @@ Below shows an example, similar to the [Wind Electrolyzer Example](https://githu
 finance_parameters:
   finance_groups:
     my_finance_model:
-      finance_model: simple_lco_finance #this is the key to give it in for supported models
-      finance_model_class_name: SimpleLCOFinance #name of the finance class
+      finance_model: SimpleLCOFinance #name of the finance class
       finance_model_location: user_finance_model/simple_lco.py #filepath of the finance model relative to the plant_config.yaml file
       model_inputs: #inputs for the finance model
         discount_rate: 0.09

--- a/docs/resource/resource_index.md
+++ b/docs/resource/resource_index.md
@@ -6,8 +6,40 @@
 - [Tidal Resource Data](tidal_resource:models)
 
 
+## Setting resource data for a technology
 
-## Custom resource models
+There are two ways to supply resource data to a technology:
+1. Set resource for a technology data [using `set_val()`](#resource-data-specified-using-setval)
+2. Create a [custom resource model](#custom-resource-models) for the technology
+
+
+
+### Resource data specified using `set_val()`
+
+Resource data for a technology can be set using the `set_val()` command. In the [Run of River Example](https://github.com/NatLabRockies/H2Integrate/tree/develop/examples/07_run_of_river_plant/), the technology named `river` needs a resource input called `discharge`. An example of this is shown below:
+
+```python
+import pandas as pd
+from h2integrate.core.h2integrate_model import H2IntegrateModel
+# Create an H2I model
+h2i = H2IntegrateModel("07_run_of_river.yaml")
+
+# Suppose we load the resource data from a csv file
+resource_df = pd.read_csv("river_resource_data.csv")
+
+# Setup the h2i model
+h2i.setup()
+
+# Set the resource data for the river
+h2i.set_val("river.discharge", val=resource_df["discharge"].values, units="m**3/s")
+
+# Run the model
+h2i.run()
+```
+
+
+### Custom resource models
+The benefit of using a custom resource model is that the resource data can be made to vary for different inputs, which can be beneficial if running a design sweep or optimization where the resource location (specified by a latitude and longitude) is a design variable.
 
 A general resource model can be defined similarly to a custom technology model. A custom resource model should be defined in the plant configuration file within a site section under `sites`.
 

--- a/docs/resource/resource_index.md
+++ b/docs/resource/resource_index.md
@@ -12,7 +12,7 @@
 A general resource model can be defined similarly to a custom technology model. A custom resource model should be defined in the plant configuration file within a site section under `sites`.
 
 ```{note}
-Note that all custom resource models must have inputs of `latitude` and `longitude`
+Note that all custom resource models must have inputs of `latitude` and `longitude`. The outputs of your custom resource model should match the expected input to whatever model its connected to.
 ```
 
 Below shows an example, similar to the [Run of River Example](https://github.com/NatLabRockies/H2Integrate/tree/develop/examples/07_run_of_river_plant/) of how to define a custom resource model within the `plant_config.yaml` file:
@@ -29,4 +29,10 @@ sites:
         resource_model_location: river_resource/river_resource_model.py
         resource_parameters:
           filename: river_data.csv
+
+resource_to_tech_connections:
+  # connect the river resource to the run-of-river hydro technology
+  - [site.river_resource, river, discharge]
 ```
+
+The output `discharge` from the custom `river_resource` model is an input to the technology `river`. The custom resource model is a class named `CustomRiverResource` and the filepath for the `CustomRiverResource` is specified as the `resource_model_location`.

--- a/docs/resource/resource_index.md
+++ b/docs/resource/resource_index.md
@@ -4,3 +4,29 @@
 - [Wind Resource Data](wind_resource:models)
 - [Solar Resource Data](solar_resource:models)
 - [Tidal Resource Data](tidal_resource:models)
+
+
+
+## Custom resource models
+
+A general resource model can be defined similarly to a custom technology model. A custom resource model should be defined in the plant configuration file within a site section under `sites`.
+
+```{note}
+Note that all custom resource models must have inputs of `latitude` and `longitude`
+```
+
+Below shows an example, similar to the [Run of River Example](https://github.com/NatLabRockies/H2Integrate/tree/develop/examples/07_run_of_river_plant/) of how to define a custom resource model within the `plant_config.yaml` file:
+
+```yaml
+sites:
+  site:
+    latitude: 32.34
+    longitude: -98.27
+    resources:
+      river_resource:
+        resource_model: CustomRiverResource
+        resource_model_class_name: CustomRiverResource
+        resource_model_location: river_resource/river_resource_model.py
+        resource_parameters:
+          filename: river_data.csv
+```

--- a/docs/resource/resource_index.md
+++ b/docs/resource/resource_index.md
@@ -25,7 +25,6 @@ sites:
     resources:
       river_resource:
         resource_model: CustomRiverResource
-        resource_model_class_name: CustomRiverResource
         resource_model_location: river_resource/river_resource_model.py
         resource_parameters:
           filename: river_data.csv

--- a/examples/06_custom_tech/tech_config.yaml
+++ b/examples/06_custom_tech/tech_config.yaml
@@ -30,16 +30,13 @@ technologies:
         cost_year: 2019
   paper_mill:
     performance_model:
-      model: paper_mill_performance
-      model_class_name: PaperMillPerformance
+      model: PaperMillPerformance
       model_location: user_defined_model/paper_mill.py
     cost_model:
-      model: paper_mill_cost
-      model_class_name: PaperMillCost
+      model: PaperMillCost
       model_location: user_defined_model/paper_mill.py
     finance_model:
-      model: paper_mill_finance
-      model_class_name: PaperMillFinance
+      model: PaperMillFinance
       model_location: user_defined_model/paper_mill.py
     model_inputs:
       performance_parameters:

--- a/examples/08_wind_electrolyzer/plant_config.yaml
+++ b/examples/08_wind_electrolyzer/plant_config.yaml
@@ -16,8 +16,7 @@ resource_to_tech_connections: [[site.wind_resource, wind, wind_resource_data]]
 finance_parameters:
   finance_groups:
     custom_model:
-      finance_model: simple_lco_finance
-      finance_model_class_name: SimpleLCOFinance
+      finance_model: SimpleLCOFinance
       finance_model_location: user_finance_model/simple_lco.py
       model_inputs:
         discount_rate: 0.09

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -258,7 +258,7 @@ class H2IntegrateModel:
                             raise (
                                 ValueError(
                                     "User has specified two custom models using the same model"
-                                    "name ({model_name}), but with different model classes. "
+                                    f"name ({model_name}), but with different model classes. "
                                     "Technologies defined with different classes must have "
                                     "different technology names."
                                 )
@@ -350,6 +350,26 @@ class H2IntegrateModel:
                     finance_model_names,
                     prefix="finance_",
                 )
+
+        # check for custom resource models
+        if "sites" in self.plant_config:
+            for site_name, site_params in self.plant_config["sites"].items():
+                if "resources" in site_params:
+                    resource_models_config = {
+                        k: v
+                        for k, v in site_params["resources"].items()
+                        if "resource_parameters" in v
+                    }
+
+                    resource_model_names = [
+                        k for k, v in site_params["resources"].items() if "resource_parameters" in v
+                    ]
+                    self.create_custom_models(
+                        {site_name: resource_models_config},
+                        self.plant_parent_path,
+                        resource_model_names,
+                        prefix="resource_",
+                    )
 
     def create_site_model(self):
         """

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -324,7 +324,7 @@ class H2IntegrateModel:
         self.create_custom_models(
             self.technology_config["technologies"],
             self.tech_parent_path,
-            ["performance_model", "cost_model", "finance_model", "control_strategy"],
+            ["performance_model", "cost_model", "finance_model"],
         )
 
         # check for custom finance models

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -250,7 +250,7 @@ class H2IntegrateModel:
                     # of the same custom model. Also check that all instances of the same custom
                     # model tech name use the same class definition.
                     if model_name in included_custom_models:
-                        model_class_name = config[model_type].get(f"{prefix}model_class_name")
+                        model_class_name = config[model_type].get(f"{prefix}model")
                         if (
                             model_class_name
                             != included_custom_models[model_name]["model_class_name"]
@@ -267,7 +267,7 @@ class H2IntegrateModel:
                             continue
 
                     if (model_name not in self.supported_models) and (model_name is not None):
-                        model_class_name = config[model_type].get(f"{prefix}model_class_name")
+                        model_class_name = config[model_type].get(f"{prefix}model")
                         model_location = config[model_type].get(f"{prefix}model_location")
 
                         if not model_class_name or not model_location:
@@ -307,7 +307,7 @@ class H2IntegrateModel:
                             or config[model_type].get(f"{prefix}model_location") is not None
                         ):
                             msg = (
-                                f"Custom {prefix}model_class_name or {prefix}model_location "
+                                f"Custom {prefix}model or {prefix}model_location "
                                 f"specified for '{model_name}', "
                                 f"but '{model_name}' is a built-in H2Integrate "
                                 "model. Using built-in model instead is not allowed. "
@@ -324,7 +324,7 @@ class H2IntegrateModel:
         self.create_custom_models(
             self.technology_config["technologies"],
             self.tech_parent_path,
-            ["performance_model", "cost_model", "finance_model"],
+            ["performance_model", "cost_model", "finance_model", "control_strategy"],
         )
 
         # check for custom finance models

--- a/h2integrate/core/test/test_framework.py
+++ b/h2integrate/core/test/test_framework.py
@@ -9,9 +9,65 @@ import numpy as np
 import pytest
 
 import h2integrate.core.h2integrate_model as h2i_model_module
-from h2integrate import EXAMPLE_DIR
+from h2integrate import ROOT_DIR, EXAMPLE_DIR
 from h2integrate.core.h2integrate_model import H2IntegrateModel
 from h2integrate.core.inputs.validation import load_tech_yaml, load_plant_yaml, load_driver_yaml
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "example_folder,resource_example_folder", [("07_run_of_river_plant", None)]
+)
+def test_custom_resource_model(subtests, temp_copy_of_example):
+    example_folder = temp_copy_of_example
+
+    from h2integrate.resource.river import RiverResource
+
+    resource_model_fpath_parts = [ROOT_DIR] + RiverResource.__module__.split(".")[1:]
+    resource_model_fpath_parts[-1] = f"{resource_model_fpath_parts[-1]}.py"
+
+    # Make folder to hold custom resource model
+    custom_resource_model_dir = temp_copy_of_example / "user_defined_resource"
+    custom_resource_model_fpath = custom_resource_model_dir / "river_resource_model.py"
+    Path(custom_resource_model_dir).mkdir(exist_ok=True)
+
+    # Copy RiverResource model to custom resource model folder
+    h2i_resource_model_fpath = Path(*resource_model_fpath_parts)
+    shutil.copy(h2i_resource_model_fpath, custom_resource_model_fpath)
+
+    # Change the name of the copied RiverResource model
+    new_text = custom_resource_model_fpath.read_text().replace(
+        "RiverResource", "CustomRiverResource"
+    )
+    custom_resource_model_fpath.write_text(new_text, encoding="utf-8")
+
+    plant_config = load_plant_yaml(example_folder / "plant_config.yaml")
+    driver_config = load_driver_yaml(example_folder / "driver_config.yaml")
+    tech_config = load_tech_yaml(example_folder / "tech_config.yaml")
+
+    # modify the plant config to use a custom resource
+    custom_resource_model_inputs = {
+        "resource_model": "CustomRiverResource",
+        "resource_model_class_name": "CustomRiverResource",
+        "resource_model_location": str(custom_resource_model_fpath.absolute()),
+        "resource_parameters": plant_config["sites"]["site"]["resources"]["river_resource"][
+            "resource_parameters"
+        ],
+    }
+    plant_config["sites"]["site"]["resources"].update(
+        {"river_resource": custom_resource_model_inputs}
+    )
+
+    top_level_config = {
+        "plant_config": plant_config,
+        "technology_config": tech_config,
+        "driver_config": driver_config,
+    }
+    h2i = H2IntegrateModel(top_level_config)
+    h2i.setup()
+    h2i.run()
+
+    assert len(h2i.prob.get_val("site.river_resource.discharge")) == 8760
 
 
 @pytest.mark.unit

--- a/h2integrate/core/test/test_framework.py
+++ b/h2integrate/core/test/test_framework.py
@@ -48,7 +48,6 @@ def test_custom_resource_model(subtests, temp_copy_of_example):
     # modify the plant config to use a custom resource
     custom_resource_model_inputs = {
         "resource_model": "CustomRiverResource",
-        "resource_model_class_name": "CustomRiverResource",
         "resource_model_location": str(custom_resource_model_fpath.absolute()),
         "resource_parameters": plant_config["sites"]["site"]["resources"]["river_resource"][
             "resource_parameters"
@@ -113,7 +112,7 @@ def test_custom_model_name_clash(temp_dir, subtests):
     with subtests.test("custom model name should not match built-in model names"):
         # Assert that a ValueError is raised with the expected message when running the model
         error_msg = (
-            r"Custom model_class_name or model_location specified for '"
+            r"Custom model or model_location specified for '"
             r"BasicElectrolyzerCostModel', but 'BasicElectrolyzerCostModel' is a built-in "
             r"H2Integrate model\. "
             r"Using built-in model instead is not allowed\. "
@@ -129,7 +128,7 @@ def test_custom_model_name_clash(temp_dir, subtests):
         tech_config_data = load_tech_yaml(temp_tech_config)
 
         tech_config_data["technologies"]["electrolyzer"]["cost_model"] = {
-            "model": "new_electrolyzer_cost",
+            "model": "DummyClass",
             "model_location": "dummy_path",  # path doesn't matter; `model_location` must exist
         }
 
@@ -137,8 +136,7 @@ def test_custom_model_name_clash(temp_dir, subtests):
             tech_config_data["technologies"]["electrolyzer"]
         )
         tech_config_data["technologies"]["electrolyzer2"]["cost_model"] = {
-            "model": "new_electrolyzer_cost",
-            "model_class_name": "DummyClass",
+            "model": "DummyClass",
             "model_location": "dummy_path",  # path doesn't matter; `model_location` must exist
         }
         # Save the modified tech_config YAML back


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELETE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code highlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Ability to have a user-defined resource model
<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
Currently, H2I allows for users to provide custom finance models and custom technology models. With this PR, users can also specify a custom resource model!

```yaml
sites:
  site:
    latitude: 32.34
    longitude: -98.27
    resources:
      river_resource:
        resource_model: CustomRiverResource
        resource_model_location: river_resource/river_resource_model.py
        resource_parameters:
          filename: river_data.csv
```

Another update was made to the custom model definition. The custom model definition was still using the logic of "nicknaming" classes in `supported_models` (we have since updated the model naming convention to just use the model class name). Now - the custom models are simply defined by the class name and the model location (rather than requiring a nickname). For example, before we would've done this:

```yaml
resource_model: custom_river_resource
resource_model_class_name: CustomRiverResource
resource_model_location: river_resource/river_resource_model.py
```

but now we do this:

```yaml
resource_model: CustomRiverResource
resource_model_location: river_resource/river_resource_model.py
```

## Section 1: Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [ ] Feature Enhancement
  - [x] Framework
  - [ ] New Model
  - [ ] Updated Model
  - [ ] Tools/Utilities
  - [ ] Other (please describe):
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## Section 2: Draft PR Checklist
<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
<!--Complete when opening a draft PR. -->
- [x] Open draft PR
- [x] Describe the feature that will be added
- [x] Fill out TODO list steps
- [x] Describe requested feedback from reviewers on draft PR
- [x] Complete Section 7: New Model Checklist (if applicable)
<!-- Describe the feature in this PR and outline next steps -->


### Type of Reviewer Feedback Requested (on Draft PR)
<!-- Outline the feedback that would be helpful from reviewers while it's a draft PR -->
**Structural feedback**:

**Implementation feedback**:

**Other feedback**:

## Section 3: General PR Checklist
<!--Complete when converting draft PR to a merge-ready PR. -->
- [x] PR description thoroughly describes the new feature, bug fix, etc.
- [x] Added tests for new functionality or bug fixes
- [x] Tests pass (If not, and this is expected, please elaborate in the Section 6: Test Results)
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [-] Examples have been updated (if applicable)
- [ ] `CHANGELOG.md`
  - [ ] At least one complete sentence has been provided to describe the changes made in this PR
  - [ ] After the above, a hyperlink has been provided to the PR using the following format:
    "A complete thought. [PR XYZ]((https://github.com/NatLabRockies/H2Integrate/pull/XYZ)", where
    `XYZ` should be replaced with the actual number.

## Section 4: Related Issues
<!--If this PR relates to an existing GitHub issue, please link the issue and indicate whether this PR would fully or partially resolve that issue. Please also link any issues that were created due to this PR-->


## Section 5: Impacted Areas of the Software
<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why. Can exclude CHANGELOG.md, doc pages and supported_models.py.
-->
### Section 5.1: New Files
N/A

### Section 5.2: Modified Files
- `H2IntegrateModel` in `h2integrate/core/h2integrate_model.py`
  - `collect_custom_models()`: added logic to check for custom resource models
  -  `create_custom_models()`: minor update to an error message
- `h2integrate/core/test/test_framework.py`: added test `test_custom_resource_model` for new functionality leveraging example 7
- `docs/resource/resource_index.md`: updated doc page to describe how to add a custom resource model

## Section 6: Additional Supporting Information
<!--Add any other context about the problem here.-->


## Section 7: Test Results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->





<!--
__ For NLR use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NatLabRockies/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
