### PR TITLE
SLC: Adding marginal_cost calcs

### DIFF
--- a/examples/35_system_level_control/profit_maximization/plant_config.yaml
+++ b/examples/35_system_level_control/profit_maximization/plant_config.yaml
@@ -26,5 +26,7 @@ plant:
 system_level_control:
   control_strategy: ProfitMaximizationControl
   commodity_sell_price: 0.06  # $/kWh default; overridden in run script
+  cost_per_tech:
+    natural_gas_plant: feedstock  # use upstream feedstock (ng_feedstock) VarOpEx
   solver_name: gauss_seidel
   max_iter: 20

--- a/examples/35_system_level_control/profit_maximization/run_profit_max.py
+++ b/examples/35_system_level_control/profit_maximization/run_profit_max.py
@@ -59,22 +59,22 @@ price = sell_price[:n_hours]
 fig, axes = plt.subplots(4, 1, figsize=(14, 12), sharex=True)
 
 # Panel 1: stacked supply vs demand
-axes[0].fill_between(hours, 0, wind_out, alpha=0.7, color="tab:blue", label="Wind")
+axes[0].fill_between(hours, 0, ng_out, alpha=0.7, color="tab:orange", label="Natural Gas")
 axes[0].fill_between(
     hours,
-    wind_out,
-    wind_out + batt_discharge,
+    ng_out,
+    ng_out + batt_discharge,
     alpha=0.7,
     color="tab:purple",
     label="Battery Discharge",
 )
 axes[0].fill_between(
     hours,
-    wind_out + batt_discharge,
-    wind_out + batt_discharge + ng_out,
+    ng_out + batt_discharge,
+    ng_out + batt_discharge + wind_out,
     alpha=0.7,
-    color="tab:orange",
-    label="Natural Gas",
+    color="tab:blue",
+    label="Wind",
 )
 axes[0].plot(hours, demand, "k--", linewidth=1.5, label="Demand")
 axes[0].set_ylabel("Power (kW)")

--- a/examples/35_system_level_control/profit_maximization/tech_config.yaml
+++ b/examples/35_system_level_control/profit_maximization/tech_config.yaml
@@ -63,7 +63,6 @@ technologies:
         fixed_opex_per_kw_per_year: 10.0
         variable_opex_per_mwh: 0.0
         cost_year: 2023
-        marginal_cost: 0.05  # $/kWh — NG dispatch cost
   electrical_load_demand:
     performance_model:
       model: GenericDemandComponent

--- a/h2integrate/control/control_strategies/system_level/cost_minimization_control.py
+++ b/h2integrate/control/control_strategies/system_level/cost_minimization_control.py
@@ -15,26 +15,20 @@ class CostMinimizationControl(SystemLevelControlBase):
     3. Dispatchable techs are dispatched in ascending marginal-cost order,
        each up to its rated capacity, until remaining demand is met.
 
-    Each dispatchable technology must have a ``marginal_cost`` input
-    ($/commodity_rate_unit*h, e.g. $/kWh) representing its variable cost
-    per unit of production.  These are connected from cost model outputs
-    or set as defaults in the plant config.
+    Marginal costs are configured via ``cost_per_tech`` in the
+    ``system_level_control`` section of ``plant_config``.  Each
+    dispatchable technology's entry can be:
+
+    - A numeric value ($/commodity_unit, e.g. 0.05 for $0.05/kWh)
+    - ``"buy_price"`` - use the technology's purchase price
+    - ``"VarOpEx"``   - derive from VarOpEx / total production
     """
 
     def setup(self):
         super().setup()
 
-        # Add marginal cost inputs for dispatchable techs
-        self.dispatchable_marginal_cost_names = []
-        for tech_name in self.dispatchable_techs:
-            mc_name = f"{tech_name}_marginal_cost"
-            self.add_input(
-                mc_name,
-                val=0.0,
-                units=f"USD/({self.commodity_units}*h)",
-                desc=f"Marginal cost of {self.commodity} from {tech_name}",
-            )
-            self.dispatchable_marginal_cost_names.append(mc_name)
+        # Set up marginal cost inputs based on cost_per_tech config
+        self._setup_marginal_costs()
 
     def compute(self, inputs, outputs):
         demand = inputs[self.demand_input_name].copy()
@@ -48,9 +42,11 @@ class CostMinimizationControl(SystemLevelControlBase):
         # 3. Merit-order dispatch: cheapest dispatchable first
         remaining = np.maximum(demand, 0.0)
 
-        # Collect marginal costs and sort by ascending cost
-        marginal_costs = np.array([inputs[mc][0] for mc in self.dispatchable_marginal_cost_names])
-        dispatch_order = np.argsort(marginal_costs)
+        marginal_costs = self._compute_marginal_costs(inputs)
+
+        # Merit order: sort by mean marginal cost (cheapest first)
+        mean_costs = np.array([mc.mean() for mc in marginal_costs])
+        dispatch_order = np.argsort(mean_costs)
 
         # Initialize all dispatchable set_points to zero
         for set_point_name in self.dispatchable_set_point_names:

--- a/h2integrate/control/control_strategies/system_level/profit_maximization_control.py
+++ b/h2integrate/control/control_strategies/system_level/profit_maximization_control.py
@@ -22,8 +22,13 @@ class ProfitMaximizationControl(SystemLevelControlBase):
         ``plant_config["system_level_control"]["commodity_sell_price"]``
         must be set ($/(commodity_rate_unit*h), e.g. $/kWh).
 
-    Each dispatchable technology must have a ``marginal_cost`` input
-    representing its variable cost per unit of production.
+    Marginal costs are configured via ``cost_per_tech`` in the
+    ``system_level_control`` section of ``plant_config``.  Each
+    dispatchable technology's entry can be:
+
+    - A numeric value ($/commodity_unit, e.g. 0.05 for $0.05/kWh)
+    - ``"buy_price"`` — use the technology's purchase price
+    - ``"VarOpEx"``   — derive from VarOpEx / total production
     """
 
     def setup(self):
@@ -41,17 +46,8 @@ class ProfitMaximizationControl(SystemLevelControlBase):
             desc=f"Sell price per unit of {self.commodity}",
         )
 
-        # Add marginal cost inputs for dispatchable techs
-        self.dispatchable_marginal_cost_names = []
-        for tech_name in self.dispatchable_techs:
-            mc_name = f"{tech_name}_marginal_cost"
-            self.add_input(
-                mc_name,
-                val=0.0,
-                units=f"USD/({self.commodity_units}*h)",
-                desc=f"Marginal cost of {self.commodity} from {tech_name}",
-            )
-            self.dispatchable_marginal_cost_names.append(mc_name)
+        # Set up marginal cost inputs based on cost_per_tech config
+        self._setup_marginal_costs()
 
     def compute(self, inputs, outputs):
         demand = inputs[self.demand_input_name].copy()
@@ -66,8 +62,11 @@ class ProfitMaximizationControl(SystemLevelControlBase):
         # 3. Profit-driven merit-order dispatch
         remaining = np.maximum(demand, 0.0)
 
-        marginal_costs = np.array([inputs[mc][0] for mc in self.dispatchable_marginal_cost_names])
-        dispatch_order = np.argsort(marginal_costs)
+        marginal_costs = self._compute_marginal_costs(inputs)
+
+        # Merit order: sort by mean marginal cost (cheapest first)
+        mean_costs = np.array([mc.mean() for mc in marginal_costs])
+        dispatch_order = np.argsort(mean_costs)
 
         # Initialize all dispatchable set_points to zero
         for set_point_name in self.dispatchable_set_point_names:
@@ -75,7 +74,7 @@ class ProfitMaximizationControl(SystemLevelControlBase):
 
         # Dispatch only where profitable (element-wise comparison)
         for idx in dispatch_order:
-            mc = marginal_costs[idx]
+            mc = marginal_costs[idx]  # per-timestep array
             profitable = mc < sell_price  # boolean mask per timestep
 
             set_point_name = self.dispatchable_set_point_names[idx]

--- a/h2integrate/control/control_strategies/system_level/system_level_control_base.py
+++ b/h2integrate/control/control_strategies/system_level/system_level_control_base.py
@@ -176,13 +176,13 @@ class SystemLevelControlBase(om.ExplicitComponent):
         """Create OpenMDAO I/O variables for all technologies in a given category.
 
         This single method handles curtailable, dispatchable, and storage
-        technologies.  The logic is identical for all three categories —
+        technologies. The logic is identical for all three categories —
         iterate over each technology's commodities and register the
         appropriate inputs (production output, rated capacity) and output
         (control set-point) — with one difference:
 
         * **Curtailable / Storage** (``demand_profile is None``):
-          ``initial_set_point`` is ``0.0``.  Curtailable techs are later
+          ``initial_set_point`` is ``0.0``. Curtailable techs are later
           assigned set-points equal to their rated production; storage techs
           get set-points computed at run-time in ``_dispatch_storage``.
 
@@ -204,11 +204,11 @@ class SystemLevelControlBase(om.ExplicitComponent):
 
         Args:
             category (str): One of ``"curtailable"``, ``"dispatchable"``,
-                or ``"storage"``.  Used to name the attribute lists.
+                or ``"storage"``. Used to name the attribute lists.
             tech_list (list[str]): Technology names belonging to this category
                 (e.g. ``self.curtailable_techs``).
             demand_profile (float | np.ndarray | None, optional):
-                Only relevant for **dispatchable** techs.  When provided, the
+                Only relevant for **dispatchable** techs. When provided, the
                 demand is split equally among dispatchable techs that produce
                 the demanded commodity to set a non-zero ``initial_set_point``.
                 For curtailable and storage techs, leave as ``None`` (default).
@@ -359,3 +359,234 @@ class SystemLevelControlBase(om.ExplicitComponent):
         tech_commodities = [e[1] for e in self.techs_to_commodities if e[0] == tech_name]
 
         return tech_commodities
+
+    # ------------------------------------------------------------------
+    # Marginal-cost helpers for cost-aware controllers
+    # ------------------------------------------------------------------
+
+    def _setup_marginal_costs(self):
+        """Set up marginal cost inputs for dispatchable techs based on ``cost_per_tech``.
+
+        Should be called from ``setup()`` of cost-aware controllers
+        (e.g., ``CostMinimizationControl``, ``ProfitMaximizationControl``).
+
+        Reads ``cost_per_tech`` from
+        ``plant_config["system_level_control"]`` and creates appropriate
+        OpenMDAO inputs for each dispatchable technology:
+
+        - Numeric value (e.g. ``0.05``): used directly as a constant
+          marginal cost in ``USD/(commodity_rate_unit*h)``. No additional
+          inputs or connections are required.
+        - ``"buy_price"``: creates a ``{tech_name}_buy_price`` input
+          whose default value is read from the technology's cost config
+          (``electricity_buy_price`` for Grid, ``price`` for Feedstock).
+          Can be scalar or time-varying and may be overridden at runtime
+          via ``prob.set_val()``.
+        - ``"VarOpEx"``: creates a ``{tech_name}_VarOpEx`` input
+          connected to the cost model's ``VarOpEx`` output. The
+          per-unit marginal cost is computed at run time by dividing
+          ``VarOpEx`` by the total production.
+        - ``"feedstock"``: looks up ``technology_interconnections`` to
+          find all feedstock technologies connected upstream of the
+          dispatchable tech, sums their ``VarOpEx`` outputs, and
+          divides by the tech's total production. Handles the common
+          single-feedstock case as well as multiple feedstock streams.
+        """
+        slc_config = self.options["plant_config"]["system_level_control"]
+        self.cost_per_tech = slc_config.get("cost_per_tech", {})
+        self.dt_hours = self.options["plant_config"]["plant"]["simulation"]["dt"] / 3600
+        hours_simulated = self.dt_hours * self.n_timesteps
+        self.fraction_of_year_simulated = hours_simulated / 8760
+        plant_life = int(self.options["plant_config"]["plant"]["plant_life"])
+
+        self.dispatchable_marginal_cost_types = []
+
+        for tech_name in self.dispatchable_techs:
+            cost_spec = self.cost_per_tech.get(tech_name, 0.0)
+
+            if isinstance(cost_spec, int | float):
+                self.dispatchable_marginal_cost_types.append(("scalar", cost_spec))
+
+            elif cost_spec == "buy_price":
+                # Read default buy price from tech config
+                tech_config = self.options["tech_config"]
+                tech_def = tech_config.get("technologies", {}).get(tech_name, {})
+                model_inputs = tech_def.get("model_inputs", {})
+                cost_params = model_inputs.get("cost_parameters", {})
+                shared_params = model_inputs.get("shared_parameters", {})
+                all_params = {**shared_params, **cost_params}
+
+                default_price = all_params.get(
+                    "electricity_buy_price",
+                    all_params.get("price", 0.0),
+                )
+
+                self.add_input(
+                    f"{tech_name}_buy_price",
+                    val=default_price,
+                    shape=self.n_timesteps,
+                    units=f"USD/({self.commodity_units}*h)",
+                    desc=f"Buy price for {tech_name}",
+                )
+                self.dispatchable_marginal_cost_types.append(("buy_price", tech_name))
+
+            elif cost_spec == "VarOpEx":
+                self.add_input(
+                    f"{tech_name}_VarOpEx",
+                    val=0.0,
+                    shape=plant_life,
+                    units="USD/year",
+                    desc=f"Variable operating expenditure from {tech_name}",
+                )
+                self.dispatchable_marginal_cost_types.append(("VarOpEx", tech_name))
+
+            elif cost_spec == "feedstock":
+                # Find feedstock techs connected upstream of this tech
+                feedstock_names = self._find_feedstock_techs(tech_name)
+                if not feedstock_names:
+                    raise ValueError(
+                        f"cost_per_tech '{cost_spec}' for '{tech_name}' requires "
+                        f"at least one feedstock connected upstream in "
+                        f"technology_interconnections, but none were found."
+                    )
+                for feedstock_name in feedstock_names:
+                    self.add_input(
+                        f"{feedstock_name}_VarOpEx",
+                        val=0.0,
+                        shape=plant_life,
+                        units="USD/year",
+                        desc=f"Variable operating expenditure from feedstock {feedstock_name}",
+                    )
+                self.dispatchable_marginal_cost_types.append(
+                    ("feedstock", (tech_name, feedstock_names))
+                )
+
+            else:
+                raise ValueError(
+                    f"Unknown cost_per_tech value '{cost_spec}' for '{tech_name}'. "
+                    f"Must be a numeric value, 'buy_price', 'VarOpEx', or 'feedstock'."
+                )
+
+    def _compute_marginal_costs(self, inputs):
+        """Compute per-timestep marginal costs for each dispatchable tech.
+
+        Returns:
+            list[np.ndarray]: marginal cost arrays, one per dispatchable
+            tech, each of shape ``(n_timesteps,)``.
+        """
+        marginal_costs = []
+
+        for marginal_cost_type, marginal_cost_data in self.dispatchable_marginal_cost_types:
+            if marginal_cost_type == "scalar":
+                marginal_cost = np.full(self.n_timesteps, marginal_cost_data)
+            elif marginal_cost_type == "buy_price":
+                marginal_cost = self._buy_price_marginal_cost(inputs, marginal_cost_data)
+            elif marginal_cost_type == "VarOpEx":
+                marginal_cost = self._varopex_marginal_cost(inputs, marginal_cost_data)
+            elif marginal_cost_type == "feedstock":
+                marginal_cost = self._feedstock_marginal_cost(inputs, marginal_cost_data)
+            else:
+                marginal_cost = np.zeros(self.n_timesteps)
+
+            marginal_costs.append(marginal_cost)
+
+        return marginal_costs
+
+    def _buy_price_marginal_cost(self, inputs, tech_name):
+        """Compute marginal cost from buy price.
+
+        Returns a per-timestep marginal cost array equal to the
+        technology's buy price (scalar or time-varying).
+        """
+        return np.broadcast_to(inputs[f"{tech_name}_buy_price"], self.n_timesteps).copy()
+
+    def _varopex_marginal_cost(self, inputs, tech_name):
+        """Compute marginal cost from VarOpEx and commodity output.
+
+        Divides the first-year ``VarOpEx`` (``$/year``) by the
+        annualized total production to obtain an average marginal cost
+        in ``$/(commodity_amount_unit)``.
+
+        Returns a constant per-timestep array.
+        """
+        varopex = inputs[f"{tech_name}_VarOpEx"]  # $/year, shape=plant_life
+
+        # Use commodity_out already connected for this dispatchable tech
+        tech_commodities = self._get_commodity_for_tech(tech_name)
+        commodity = tech_commodities[0] if tech_commodities else self.commodity
+
+        production = inputs[f"{tech_name}_{commodity}_out"]  # rate units, shape=n_timesteps
+        total_production = production.sum() * self.dt_hours
+
+        if total_production > 0:
+            annual_production = total_production / self.fraction_of_year_simulated
+            marginal_cost_scalar = varopex[0] / annual_production
+        else:
+            marginal_cost_scalar = 0.0
+
+        return np.full(self.n_timesteps, marginal_cost_scalar)
+
+    def _find_feedstock_techs(self, tech_name):
+        """Find feedstock technologies connected upstream of tech_name.
+
+        Scans ``technology_interconnections`` for connections whose
+        destination is tech_name and whose source uses
+        ``FeedstockPerformanceModel`` or ``FeedstockCostModel``.
+
+        Args:
+            tech_name (str): the dispatchable technology name.
+
+        Returns:
+            list[str]: names of upstream feedstock technologies.
+        """
+        tech_config = self.options["tech_config"]
+        technologies = tech_config.get("technologies", {})
+        interconnections = self.options["plant_config"].get("technology_interconnections", [])
+
+        # Upstream tech names for this dispatchable tech
+        upstream_techs = [conn[0] for conn in interconnections if conn[1] == tech_name]
+
+        feedstock_names = []
+        for upstream in upstream_techs:
+            tech_def = technologies.get(upstream, {})
+            perf_model = tech_def.get("performance_model", {}).get("model", "")
+            cost_model = tech_def.get("cost_model", {}).get("model", "")
+            if "Feedstock" in perf_model or "Feedstock" in cost_model:
+                feedstock_names.append(upstream)
+
+        return feedstock_names
+
+    def _feedstock_marginal_cost(self, inputs, marginal_cost_data):
+        """Compute marginal cost from upstream feedstock VarOpEx values.
+
+        Sums the first-year ``VarOpEx`` from all feedstock technologies
+        connected to the dispatchable tech, then divides by the tech's
+        annualized total production.
+
+        Args:
+            marginal_cost_data (tuple): ``(tech_name, feedstock_names)`` where
+                tech_name is the dispatchable tech and feedstock_names
+                is a list of upstream feedstock technology names.
+
+        Returns:
+            np.ndarray: constant per-timestep marginal cost array.
+        """
+        tech_name, feedstock_names = marginal_cost_data
+
+        # Sum VarOpEx from all connected feedstocks (first year)
+        total_varopex = sum(inputs[f"{fs}_VarOpEx"][0] for fs in feedstock_names)
+
+        # Get the tech's production
+        tech_commodities = self._get_commodity_for_tech(tech_name)
+        commodity = tech_commodities[0] if tech_commodities else self.commodity
+
+        production = inputs[f"{tech_name}_{commodity}_out"]
+        total_production = production.sum() * self.dt_hours
+
+        if total_production > 0:
+            annual_production = total_production / self.fraction_of_year_simulated
+            marginal_cost_scalar = total_varopex / annual_production
+        else:
+            marginal_cost_scalar = 0.0
+
+        return np.full(self.n_timesteps, marginal_cost_scalar)

--- a/h2integrate/control/control_strategies/system_level/test/test_slc_controllers.py
+++ b/h2integrate/control/control_strategies/system_level/test/test_slc_controllers.py
@@ -1,0 +1,539 @@
+"""Unit tests for system-level control base class and all controller strategies."""
+
+import numpy as np
+import pytest
+import openmdao.api as om
+
+from h2integrate.control.control_strategies.system_level.demand_following_control import (
+    DemandFollowingControl,
+)
+from h2integrate.control.control_strategies.system_level.cost_minimization_control import (
+    CostMinimizationControl,
+)
+from h2integrate.control.control_strategies.system_level.profit_maximization_control import (
+    ProfitMaximizationControl,
+)
+
+
+def _make_plant_config(
+    n_timesteps=4,
+    demand=50000,
+    curtailable=None,
+    dispatchable=None,
+    storage=None,
+    sell_price=0.06,
+    cost_per_tech=None,
+    technology_interconnections=None,
+):
+    """Build a minimal plant_config dict for controller tests."""
+    all_techs = (curtailable or []) + (dispatchable or []) + (storage or [])
+    tech_to_commodity = {(t, "electricity") for t in all_techs}
+    config = {
+        "plant": {"simulation": {"n_timesteps": n_timesteps, "dt": 3600}, "plant_life": 30},
+        "system_level_control": {
+            "demand_commodity": "electricity",
+            "demand_commodity_rate_units": "kW",
+            "demand_tech": "demand",
+            "demand_profile": demand,
+            "curtailable_techs": curtailable or [],
+            "dispatchable_techs": dispatchable or [],
+            "storage_techs": storage or [],
+            "tech_to_commodity": tech_to_commodity,
+            "commodity_sell_price": sell_price,
+            "cost_per_tech": cost_per_tech or {},
+        },
+    }
+    if technology_interconnections is not None:
+        config["technology_interconnections"] = technology_interconnections
+    return config
+
+
+def _build_problem(slc_cls, plant_config, tech_config=None):
+    """Create and setup an OpenMDAO Problem with the given controller."""
+    prob = om.Problem()
+    prob.model.add_subsystem(
+        "slc",
+        slc_cls(
+            driver_config={},
+            plant_config=plant_config,
+            tech_config=tech_config or {},
+        ),
+    )
+    prob.setup()
+    return prob
+
+
+# ---------------------------------------------------------------------------
+# SystemLevelControlBase
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestSystemLevelControlBase:
+    """Tests for the abstract base class setup logic."""
+
+    def test_base_creates_curtailable_io(self):
+        pc = _make_plant_config(curtailable=["wind"])
+        # Use DemandFollowingControl since base is abstract
+        prob = _build_problem(DemandFollowingControl, pc)
+        # _var_rel2meta uses relative names (no "slc." prefix)
+        assert "wind_electricity_out" in prob.model.slc._var_rel2meta
+        assert "wind_rated_electricity_production" in prob.model.slc._var_rel2meta
+        assert "wind_electricity_set_point" in prob.model.slc._var_rel2meta
+
+    def test_base_creates_dispatchable_io(self):
+        pc = _make_plant_config(dispatchable=["ng"])
+        prob = _build_problem(DemandFollowingControl, pc)
+        assert "ng_electricity_out" in prob.model.slc._var_rel2meta
+        assert "ng_rated_electricity_production" in prob.model.slc._var_rel2meta
+        assert "ng_electricity_set_point" in prob.model.slc._var_rel2meta
+
+    def test_base_creates_storage_io(self):
+        pc = _make_plant_config(storage=["battery"])
+        prob = _build_problem(DemandFollowingControl, pc)
+        assert "battery_electricity_out" in prob.model.slc._var_rel2meta
+        assert "battery_rated_electricity_production" in prob.model.slc._var_rel2meta
+        assert "battery_electricity_set_point" in prob.model.slc._var_rel2meta
+
+    def test_base_creates_demand_input(self):
+        pc = _make_plant_config()
+        prob = _build_problem(DemandFollowingControl, pc)
+        assert "electricity_demand" in prob.model.slc._var_rel2meta
+
+    def test_backward_compat_alias(self):
+        """DemandFollowingControl should be an alias for DemandFollowingControl."""
+        assert DemandFollowingControl is DemandFollowingControl
+
+
+# ---------------------------------------------------------------------------
+# DemandFollowingControl
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestDemandFollowingControl:
+    """Tests for the demand-following (equal-share) controller."""
+
+    def test_equal_share_two_dispatchable(self):
+        pc = _make_plant_config(dispatchable=["ng1", "ng2"])
+        prob = _build_problem(DemandFollowingControl, pc)
+        prob.set_val("slc.ng1_rated_electricity_production", 80000)
+        prob.set_val("slc.ng2_rated_electricity_production", 40000)
+        prob.run_model()
+
+        sp1 = prob.get_val("slc.ng1_electricity_set_point")
+        sp2 = prob.get_val("slc.ng2_electricity_set_point")
+        np.testing.assert_allclose(sp1, 25000)
+        np.testing.assert_allclose(sp2, 25000)
+
+    def test_curtailable_reduces_demand(self):
+        pc = _make_plant_config(curtailable=["wind"], dispatchable=["ng"])
+        prob = _build_problem(DemandFollowingControl, pc)
+        prob.set_val("slc.wind_electricity_out", [30000, 60000, 50000, 10000])
+        prob.set_val("slc.wind_rated_electricity_production", 120000)
+        prob.set_val("slc.ng_rated_electricity_production", 100000)
+        prob.run_model()
+
+        ng_sp = prob.get_val("slc.ng_electricity_set_point")
+        # demand=50k, wind outputs [30k,60k,50k,10k] → remaining = max(0, demand-wind)
+        expected = np.maximum(50000 - np.array([30000, 60000, 50000, 10000]), 0)
+        np.testing.assert_allclose(ng_sp, expected)
+
+    def test_storage_absorbs_surplus(self):
+        pc = _make_plant_config(curtailable=["wind"], storage=["battery"], dispatchable=["ng"])
+        prob = _build_problem(DemandFollowingControl, pc)
+        prob.set_val("slc.wind_electricity_out", [70000, 30000, 50000, 50000])
+        prob.set_val("slc.wind_rated_electricity_production", 120000)
+        prob.set_val("slc.battery_electricity_out", [0, 0, 0, 0])
+        prob.set_val("slc.battery_rated_electricity_production", 50000)
+        prob.set_val("slc.ng_rated_electricity_production", 100000)
+        prob.run_model()
+
+        batt_sp = prob.get_val("slc.battery_electricity_set_point")
+        # demand - wind = [50k-70k, 50k-30k, 0, 0] = [-20k, 20k, 0, 0]
+        expected = np.array([-20000, 20000, 0, 0])
+        np.testing.assert_allclose(batt_sp, expected)
+
+    def test_no_techs_runs(self):
+        """Controller with no techs should still run without error."""
+        pc = _make_plant_config()
+        prob = _build_problem(DemandFollowingControl, pc)
+        prob.run_model()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# CostMinimizationControl
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestCostMinimizationControl:
+    """Tests for the merit-order cost-minimization controller."""
+
+    def test_cheapest_dispatched_first(self):
+        pc = _make_plant_config(
+            dispatchable=["cheap", "expensive"],
+            demand=50000,
+            cost_per_tech={"cheap": 0.03, "expensive": 0.08},
+        )
+        prob = _build_problem(CostMinimizationControl, pc)
+        prob.set_val("slc.cheap_rated_electricity_production", 80000)
+        prob.set_val("slc.expensive_rated_electricity_production", 40000)
+        prob.run_model()
+
+        cheap_sp = prob.get_val("slc.cheap_electricity_set_point")
+        expensive_sp = prob.get_val("slc.expensive_electricity_set_point")
+        # Cheap can handle all 50k (rated 80k), so expensive gets 0
+        np.testing.assert_allclose(cheap_sp, 50000)
+        np.testing.assert_allclose(expensive_sp, 0)
+
+    def test_overflow_to_expensive(self):
+        pc = _make_plant_config(
+            dispatchable=["cheap", "expensive"],
+            demand=50000,
+            cost_per_tech={"cheap": 0.03, "expensive": 0.08},
+        )
+        prob = _build_problem(CostMinimizationControl, pc)
+        prob.set_val("slc.cheap_rated_electricity_production", 30000)
+        prob.set_val("slc.expensive_rated_electricity_production", 40000)
+        prob.run_model()
+
+        cheap_sp = prob.get_val("slc.cheap_electricity_set_point")
+        expensive_sp = prob.get_val("slc.expensive_electricity_set_point")
+        # Cheap maxes at 30k, expensive picks up remaining 20k
+        np.testing.assert_allclose(cheap_sp, 30000)
+        np.testing.assert_allclose(expensive_sp, 20000)
+
+    def test_with_curtailable_reduces_dispatch(self):
+        pc = _make_plant_config(
+            curtailable=["wind"],
+            dispatchable=["ng"],
+            demand=50000,
+            cost_per_tech={"ng": 0.05},
+        )
+        prob = _build_problem(CostMinimizationControl, pc)
+        prob.set_val("slc.wind_electricity_out", [40000, 40000, 40000, 40000])
+        prob.set_val("slc.wind_rated_electricity_production", 120000)
+        prob.set_val("slc.ng_rated_electricity_production", 100000)
+        prob.run_model()
+
+        ng_sp = prob.get_val("slc.ng_electricity_set_point")
+        # demand 50k - wind 40k = 10k remaining
+        np.testing.assert_allclose(ng_sp, 10000)
+
+
+# ---------------------------------------------------------------------------
+# ProfitMaximizationControl
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestProfitMaximizationControl:
+    """Tests for the profit-maximization controller."""
+
+    def test_unprofitable_tech_not_dispatched(self):
+        pc = _make_plant_config(
+            dispatchable=["cheap", "expensive"],
+            demand=50000,
+            sell_price=0.06,
+            cost_per_tech={"cheap": 0.03, "expensive": 0.08},
+        )
+        prob = _build_problem(ProfitMaximizationControl, pc)
+        prob.set_val("slc.cheap_rated_electricity_production", 30000)
+        prob.set_val("slc.expensive_rated_electricity_production", 40000)
+        prob.set_val("slc.commodity_sell_price", 0.06)
+        prob.run_model()
+
+        cheap_sp = prob.get_val("slc.cheap_electricity_set_point")
+        expensive_sp = prob.get_val("slc.expensive_electricity_set_point")
+        # Cheap (0.03 < 0.06) dispatched up to rated 30k
+        # Expensive (0.08 >= 0.06) NOT dispatched, demand unmet
+        np.testing.assert_allclose(cheap_sp, 30000)
+        np.testing.assert_allclose(expensive_sp, 0)
+
+    def test_all_profitable(self):
+        pc = _make_plant_config(
+            dispatchable=["a", "b"],
+            demand=50000,
+            sell_price=0.10,
+            cost_per_tech={"a": 0.03, "b": 0.05},
+        )
+        prob = _build_problem(ProfitMaximizationControl, pc)
+        prob.set_val("slc.a_rated_electricity_production", 80000)
+        prob.set_val("slc.b_rated_electricity_production", 40000)
+        prob.set_val("slc.commodity_sell_price", 0.10)
+        prob.run_model()
+
+        a_sp = prob.get_val("slc.a_electricity_set_point")
+        b_sp = prob.get_val("slc.b_electricity_set_point")
+        # Both profitable, cheapest first: a gets 50k (rated 80k), b gets 0
+        np.testing.assert_allclose(a_sp, 50000)
+        np.testing.assert_allclose(b_sp, 0)
+
+    def test_none_profitable(self):
+        pc = _make_plant_config(
+            dispatchable=["ng"],
+            demand=50000,
+            sell_price=0.01,
+            cost_per_tech={"ng": 0.05},
+        )
+        prob = _build_problem(ProfitMaximizationControl, pc)
+        prob.set_val("slc.ng_rated_electricity_production", 100000)
+        prob.set_val("slc.commodity_sell_price", 0.01)
+        prob.run_model()
+
+        ng_sp = prob.get_val("slc.ng_electricity_set_point")
+        # NG cost (0.05) >= sell price (0.01), not dispatched
+        np.testing.assert_allclose(ng_sp, 0)
+
+    def test_sell_price_from_config(self):
+        pc = _make_plant_config(
+            dispatchable=["ng"],
+            demand=50000,
+            sell_price=0.10,
+            cost_per_tech={"ng": 0.03},
+        )
+        prob = _build_problem(ProfitMaximizationControl, pc)
+        prob.set_val("slc.ng_rated_electricity_production", 100000)
+        # Don't set sell_price explicitly — should use config default 0.10
+        prob.run_model()
+
+        ng_sp = prob.get_val("slc.ng_electricity_set_point")
+        # Config sell_price=0.10 > marginal 0.03 → dispatched
+        np.testing.assert_allclose(ng_sp, 50000)
+
+    def test_time_varying_sell_price(self):
+        pc = _make_plant_config(
+            dispatchable=["ng"],
+            demand=50000,
+            sell_price=0.06,
+            cost_per_tech={"ng": 0.05},
+        )
+        prob = _build_problem(ProfitMaximizationControl, pc)
+        prob.set_val("slc.ng_rated_electricity_production", 100000)
+        # Sell price varies: 2 profitable hours, 2 unprofitable
+        prob.set_val("slc.commodity_sell_price", [0.08, 0.03, 0.10, 0.02])
+        prob.run_model()
+
+        ng_sp = prob.get_val("slc.ng_electricity_set_point")
+        # mc=0.05: profitable when sell>0.05 (hours 0,2), not when sell<0.05 (hours 1,3)
+        np.testing.assert_allclose(ng_sp, [50000, 0, 50000, 0])
+
+    def test_buy_price_scalar(self):
+        """buy_price mode with a scalar buy price from tech config."""
+        pc = _make_plant_config(
+            dispatchable=["grid"],
+            demand=50000,
+            sell_price=0.10,
+            cost_per_tech={"grid": "buy_price"},
+        )
+        # Add tech config with buy price
+        tech_config = {
+            "technologies": {
+                "grid": {
+                    "model_inputs": {
+                        "cost_parameters": {"electricity_buy_price": 0.04},
+                    }
+                }
+            }
+        }
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "slc",
+            ProfitMaximizationControl(driver_config={}, plant_config=pc, tech_config=tech_config),
+        )
+        prob.setup()
+        prob.set_val("slc.grid_rated_electricity_production", 100000)
+        prob.set_val("slc.commodity_sell_price", 0.10)
+        prob.run_model()
+
+        grid_sp = prob.get_val("slc.grid_electricity_set_point")
+        # buy_price=0.04 < sell_price=0.10 → dispatched
+        np.testing.assert_allclose(grid_sp, 50000)
+
+    def test_buy_price_time_varying(self):
+        """buy_price mode with time-varying prices (override via set_val)."""
+        pc = _make_plant_config(
+            dispatchable=["grid"],
+            demand=50000,
+            sell_price=0.06,
+            cost_per_tech={"grid": "buy_price"},
+        )
+        tech_config = {
+            "technologies": {
+                "grid": {
+                    "model_inputs": {
+                        "cost_parameters": {"electricity_buy_price": 0.04},
+                    }
+                }
+            }
+        }
+        prob = om.Problem()
+        prob.model.add_subsystem(
+            "slc",
+            ProfitMaximizationControl(driver_config={}, plant_config=pc, tech_config=tech_config),
+        )
+        prob.setup()
+        prob.set_val("slc.grid_rated_electricity_production", 100000)
+        prob.set_val("slc.commodity_sell_price", 0.06)
+        # Time-varying buy price: profitable at hours 0,2; unprofitable at hours 1,3
+        prob.set_val("slc.grid_buy_price", [0.03, 0.08, 0.04, 0.09])
+        prob.run_model()
+
+        grid_sp = prob.get_val("slc.grid_electricity_set_point")
+        np.testing.assert_allclose(grid_sp, [50000, 0, 50000, 0])
+
+    def test_varopex_mode(self):
+        """VarOpEx mode computes marginal cost from VarOpEx / production."""
+        pc = _make_plant_config(
+            dispatchable=["gen"],
+            demand=50000,
+            sell_price=0.10,
+            cost_per_tech={"gen": "VarOpEx"},
+        )
+        prob = _build_problem(CostMinimizationControl, pc)
+        prob.set_val("slc.gen_rated_electricity_production", 100000)
+        # Set VarOpEx ($/year, shape=plant_life=30) and production
+        prob.set_val("slc.gen_VarOpEx", np.full(30, 500000.0))
+        # Simulate 4 hours of 100 MW production → 400 MWh
+        prob.set_val("slc.gen_electricity_out", np.full(4, 100000.0))
+        prob.run_model()
+
+        gen_sp = prob.get_val("slc.gen_electricity_set_point")
+        # VarOpEx=500k $/yr, production=100MW*4h=400MWh over 4h
+        # Annual production = 400 MWh / (4/8760) = 876,000 MWh
+        # mc = 500k / 876k ≈ 0.571 $/MWh ≈ 0.000571 $/kWh
+        # This is very cheap, so it should be dispatched fully
+        np.testing.assert_allclose(gen_sp, 50000)
+
+    def test_cost_per_tech_default_zero(self):
+        """Techs not listed in cost_per_tech default to zero marginal cost."""
+        pc = _make_plant_config(
+            dispatchable=["ng"],
+            demand=50000,
+            sell_price=0.10,
+            cost_per_tech={},  # Empty: ng defaults to 0.0
+        )
+        prob = _build_problem(ProfitMaximizationControl, pc)
+        prob.set_val("slc.ng_rated_electricity_production", 100000)
+        prob.set_val("slc.commodity_sell_price", 0.10)
+        prob.run_model()
+
+        ng_sp = prob.get_val("slc.ng_electricity_set_point")
+        # mc=0.0 < sell_price=0.10 → dispatched
+        np.testing.assert_allclose(ng_sp, 50000)
+
+    def test_feedstock_single(self):
+        """feedstock mode: single upstream feedstock drives marginal cost."""
+        pc = _make_plant_config(
+            dispatchable=["ng_plant"],
+            demand=50000,
+            sell_price=0.10,
+            cost_per_tech={"ng_plant": "feedstock"},
+            technology_interconnections=[
+                ["ng_feed", "ng_plant", "natural_gas", "pipe"],
+            ],
+        )
+        tech_config = {
+            "technologies": {
+                "ng_feed": {
+                    "performance_model": {"model": "FeedstockPerformanceModel"},
+                    "cost_model": {"model": "FeedstockCostModel"},
+                },
+            }
+        }
+        prob = _build_problem(CostMinimizationControl, pc, tech_config=tech_config)
+        prob.set_val("slc.ng_plant_rated_electricity_production", 100000)
+        # Feedstock VarOpEx: $1M/yr; production: 100 MW * 4 h = 400 MWh
+        prob.set_val("slc.ng_feed_VarOpEx", np.full(30, 1_000_000.0))
+        prob.set_val("slc.ng_plant_electricity_out", np.full(4, 100000.0))
+        prob.run_model()
+
+        sp = prob.get_val("slc.ng_plant_electricity_set_point")
+        # Annual production = 400 MWh / (4/8760) = 876,000 MWh
+        # mc = 1M / 876k ≈ 1.14 $/MWh ≈ 0.00114 $/kWh → very cheap
+        np.testing.assert_allclose(sp, 50000)
+
+    def test_feedstock_multiple(self):
+        """feedstock mode: multiple upstream feedstocks are summed."""
+        pc = _make_plant_config(
+            dispatchable=["plant"],
+            demand=50000,
+            sell_price=0.10,
+            cost_per_tech={"plant": "feedstock"},
+            technology_interconnections=[
+                ["feed_a", "plant", "gas_a", "pipe"],
+                ["feed_b", "plant", "gas_b", "pipe"],
+                ["other_tech", "plant", "something", "cable"],
+            ],
+        )
+        tech_config = {
+            "technologies": {
+                "feed_a": {
+                    "performance_model": {"model": "FeedstockPerformanceModel"},
+                    "cost_model": {"model": "FeedstockCostModel"},
+                },
+                "feed_b": {
+                    "performance_model": {"model": "FeedstockPerformanceModel"},
+                    "cost_model": {"model": "FeedstockCostModel"},
+                },
+                "other_tech": {
+                    "performance_model": {"model": "SomePerformanceModel"},
+                },
+            }
+        }
+        prob = _build_problem(CostMinimizationControl, pc, tech_config=tech_config)
+        prob.set_val("slc.plant_rated_electricity_production", 100000)
+        # Two feedstocks: $500k and $300k → total $800k/yr
+        prob.set_val("slc.feed_a_VarOpEx", np.full(30, 500_000.0))
+        prob.set_val("slc.feed_b_VarOpEx", np.full(30, 300_000.0))
+        prob.set_val("slc.plant_electricity_out", np.full(4, 100000.0))
+        prob.run_model()
+
+        sp = prob.get_val("slc.plant_electricity_set_point")
+        # Total VarOpEx = 800k, annual production = 876,000 MWh
+        # mc ≈ 0.913 $/MWh ≈ 0.000913 $/kWh → very cheap
+        np.testing.assert_allclose(sp, 50000)
+
+    def test_feedstock_profit_max_unprofitable(self):
+        """feedstock mode in profit max: unprofitable when feedstock costs exceed sell price."""
+        pc = _make_plant_config(
+            dispatchable=["ng_plant"],
+            demand=50000,
+            sell_price=0.01,  # very low sell price
+            cost_per_tech={"ng_plant": "feedstock"},
+            technology_interconnections=[
+                ["ng_feed", "ng_plant", "natural_gas", "pipe"],
+            ],
+        )
+        tech_config = {
+            "technologies": {
+                "ng_feed": {
+                    "performance_model": {"model": "FeedstockPerformanceModel"},
+                    "cost_model": {"model": "FeedstockCostModel"},
+                },
+            }
+        }
+        prob = _build_problem(ProfitMaximizationControl, pc, tech_config=tech_config)
+        prob.set_val("slc.ng_plant_rated_electricity_production", 100000)
+        prob.set_val("slc.commodity_sell_price", 0.01)
+        # Very expensive feedstock: $100M/yr → high marginal cost
+        prob.set_val("slc.ng_feed_VarOpEx", np.full(30, 100_000_000.0))
+        prob.set_val("slc.ng_plant_electricity_out", np.full(4, 100000.0))
+        prob.run_model()
+
+        sp = prob.get_val("slc.ng_plant_electricity_set_point")
+        # mc = 100M / 876k ≈ 114 $/MWh ≈ 0.114 $/kWh > sell 0.01 → NOT dispatched
+        np.testing.assert_allclose(sp, 0)
+
+    def test_feedstock_no_feedstock_raises(self):
+        """feedstock mode raises ValueError when no feedstock is found upstream."""
+        pc = _make_plant_config(
+            dispatchable=["ng_plant"],
+            demand=50000,
+            cost_per_tech={"ng_plant": "feedstock"},
+            technology_interconnections=[
+                ["some_tech", "ng_plant", "electricity", "cable"],
+            ],
+        )
+        tech_config = {
+            "technologies": {
+                "some_tech": {
+                    "performance_model": {"model": "SomePerformanceModel"},
+                },
+            }
+        }
+        with pytest.raises(ValueError, match="at least one feedstock"):
+            _build_problem(CostMinimizationControl, pc, tech_config=tech_config)

--- a/h2integrate/converters/ammonia/simple_ammonia_model.py
+++ b/h2integrate/converters/ammonia/simple_ammonia_model.py
@@ -34,6 +34,7 @@ class SimpleAmmoniaPerformanceModel(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/co2/marine/direct_ocean_capture.py
+++ b/h2integrate/converters/co2/marine/direct_ocean_capture.py
@@ -80,6 +80,7 @@ class DOCPerformanceModel(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/co2/marine/ocean_alkalinity_enhancement.py
+++ b/h2integrate/converters/co2/marine/ocean_alkalinity_enhancement.py
@@ -73,6 +73,7 @@ class OAEPerformanceModel(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/hopp/hopp_wrapper.py
+++ b/h2integrate/converters/hopp/hopp_wrapper.py
@@ -33,6 +33,7 @@ class HOPPComponent(PerformanceModelBaseClass, CacheBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "curtailable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/hydrogen/electrolyzer_baseclass.py
+++ b/h2integrate/converters/hydrogen/electrolyzer_baseclass.py
@@ -9,6 +9,7 @@ class ElectrolyzerPerformanceBaseClass(ResizeablePerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/hydrogen/geologic/h2_well_subsurface_baseclass.py
+++ b/h2integrate/converters/hydrogen/geologic/h2_well_subsurface_baseclass.py
@@ -46,6 +46,8 @@ class GeoH2SubsurfacePerformanceConfig(BaseConfig):
 
 
 class GeoH2SubsurfacePerformanceBaseClass(PerformanceModelBaseClass):
+    _control_classifier = "curtailable"
+
     """OpenMDAO component for modeling the performance of the well subsurface for
         geologic hydrogen.
 

--- a/h2integrate/converters/hydrogen/geologic/h2_well_surface_baseclass.py
+++ b/h2integrate/converters/hydrogen/geologic/h2_well_surface_baseclass.py
@@ -28,6 +28,8 @@ class GeoH2SurfacePerformanceConfig(BaseConfig):
 
 
 class GeoH2SurfacePerformanceBaseClass(PerformanceModelBaseClass):
+    _control_classifier = "dispatchable"
+
     """OpenMDAO component for modeling the performance of the wellhead surface processing for
         geologic hydrogen.
 

--- a/h2integrate/converters/hydrogen/h2_fuel_cell.py
+++ b/h2integrate/converters/hydrogen/h2_fuel_cell.py
@@ -42,6 +42,7 @@ class LinearH2FuelCellPerformanceModel(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/hydrogen/steam_methane_reformer.py
+++ b/h2integrate/converters/hydrogen/steam_methane_reformer.py
@@ -48,6 +48,7 @@ class SteamMethaneReformerPerformanceModel(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/iron/humbert_ewin_perf.py
+++ b/h2integrate/converters/iron/humbert_ewin_perf.py
@@ -79,6 +79,7 @@ class HumbertEwinPerformanceComponent(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         self.commodity = "sponge_iron"

--- a/h2integrate/converters/iron/iron_dri_base.py
+++ b/h2integrate/converters/iron/iron_dri_base.py
@@ -34,6 +34,7 @@ class IronReductionPlantBasePerformanceComponent(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/iron/martin_mine_perf_model.py
+++ b/h2integrate/converters/iron/martin_mine_perf_model.py
@@ -35,6 +35,7 @@ class MartinIronMinePerformanceComponent(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/methanol/methanol_baseclass.py
+++ b/h2integrate/converters/methanol/methanol_baseclass.py
@@ -38,6 +38,7 @@ class MethanolPerformanceBaseClass(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/natural_gas/dummy_gas_components.py
+++ b/h2integrate/converters/natural_gas/dummy_gas_components.py
@@ -65,6 +65,7 @@ class SimpleGasProducerPerformance(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()
@@ -148,6 +149,7 @@ class SimpleGasConsumerPerformance(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/nitrogen/simple_ASU.py
+++ b/h2integrate/converters/nitrogen/simple_ASU.py
@@ -69,6 +69,7 @@ class SimpleASUPerformanceModel(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/nuclear/nuclear_plant.py
+++ b/h2integrate/converters/nuclear/nuclear_plant.py
@@ -37,6 +37,7 @@ class QuinnNuclearPerformanceModel(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/steel/cmu_electric_arc_furnace_dri.py
+++ b/h2integrate/converters/steel/cmu_electric_arc_furnace_dri.py
@@ -143,6 +143,7 @@ class CMUElectricArcFurnaceDRIPerformanceComponent(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/steel/cmu_electric_arc_furnace_scrap.py
+++ b/h2integrate/converters/steel/cmu_electric_arc_furnace_scrap.py
@@ -105,6 +105,7 @@ class CMUElectricArcFurnaceScrapOnlyPerformanceComponent(PerformanceModelBaseCla
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/steel/steel_baseclass.py
+++ b/h2integrate/converters/steel/steel_baseclass.py
@@ -6,6 +6,7 @@ class SteelPerformanceBaseClass(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/steel/steel_eaf_base.py
+++ b/h2integrate/converters/steel/steel_eaf_base.py
@@ -34,6 +34,7 @@ class ElectricArcFurnacePlantBasePerformanceComponent(PerformanceModelBaseClass)
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/water/desal/desalination_baseclass.py
+++ b/h2integrate/converters/water/desal/desalination_baseclass.py
@@ -6,6 +6,7 @@ class DesalinationPerformanceBaseClass(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "dispatchable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/water_power/hydro_plant_run_of_river.py
+++ b/h2integrate/converters/water_power/hydro_plant_run_of_river.py
@@ -40,6 +40,7 @@ class RunOfRiverHydroPerformanceModel(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "curtailable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/water_power/tidal_pysam.py
+++ b/h2integrate/converters/water_power/tidal_pysam.py
@@ -124,6 +124,7 @@ class PySAMTidalPerformanceModel(PerformanceModelBaseClass):
         3600,
         3600,
     )  # (min, max) time step lengths (in seconds) compatible with this model
+    _control_classifier = "curtailable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/converters/wind/wind_plant_ard.py
+++ b/h2integrate/converters/wind/wind_plant_ard.py
@@ -38,6 +38,7 @@ class WindArdPerformanceCompatibilityComponent(PerformanceModelBaseClass):
     """
 
     _time_step_bounds = (3600, 3600)  # (min, max) time step lengths compatible with this model
+    _control_classifier = "curtailable"
 
     def initialize(self):
         super().initialize()

--- a/h2integrate/core/h2integrate_model.py
+++ b/h2integrate/core/h2integrate_model.py
@@ -645,13 +645,34 @@ class H2IntegrateModel:
                         f"{tech_name}.{commodity}_set_point",
                     )
 
-        # 4. For cost-aware strategies, connect marginal costs from cost models
+        # 4. For cost-aware strategies, connect cost inputs based on cost_per_tech
         if strategy_name in ("CostMinimizationControl", "ProfitMaximizationControl"):
+            cost_per_tech = slc_config.get("cost_per_tech", {})
             for tech_name in slc_config["dispatchable_techs"]:
-                self.plant.connect(
-                    f"{tech_name}.marginal_cost",
-                    f"system_level_controller.{tech_name}_marginal_cost",
-                )
+                cost_spec = cost_per_tech.get(tech_name, 0.0)
+                if cost_spec == "VarOpEx":
+                    self.plant.connect(
+                        f"{tech_name}.VarOpEx",
+                        f"system_level_controller.{tech_name}_VarOpEx",
+                    )
+                elif cost_spec == "feedstock":
+                    # Connect VarOpEx from each upstream feedstock
+                    interconnections = self.plant_config.get("technology_interconnections", [])
+                    technologies = self.technology_config.get("technologies", {})
+                    for conn in interconnections:
+                        if conn[1] != tech_name:
+                            continue
+                        upstream = conn[0]
+                        tech_def = technologies.get(upstream, {})
+                        perf_model = tech_def.get("performance_model", {}).get("model", "")
+                        cost_model = tech_def.get("cost_model", {}).get("model", "")
+                        if "Feedstock" in perf_model or "Feedstock" in cost_model:
+                            self.plant.connect(
+                                f"{upstream}.VarOpEx",
+                                f"system_level_controller.{upstream}_VarOpEx",
+                            )
+                # buy_price: defaults from tech config, overridable via set_val
+                # scalar: no connection needed
 
         ### Commented out for now; we'll need to determine how to treat demand
         ### components in the new SLC paradigm.

--- a/h2integrate/core/model_baseclasses.py
+++ b/h2integrate/core/model_baseclasses.py
@@ -152,7 +152,6 @@ class PerformanceModelBaseClass(om.ExplicitComponent):
 @define(kw_only=True)
 class CostModelBaseConfig(BaseConfig):
     cost_year: int = field(converter=int)
-    marginal_cost: float = field(default=0.0)
 
 
 class CostModelBaseClass(om.ExplicitComponent):
@@ -165,7 +164,6 @@ class CostModelBaseClass(om.ExplicitComponent):
         - CapEx (float): capital expenditure costs in $
         - OpEx (float): annual fixed operating expenditure costs in $/year
         - VarOpEx (float): annual variable operating expenditure costs in $/year
-        - marginal_cost (float): marginal cost of production for dispatch decisions
 
     Discrete Outputs:
         - cost_year (int): dollar-year corresponding to CapEx and OpEx values.
@@ -192,17 +190,6 @@ class CostModelBaseClass(om.ExplicitComponent):
         # Define discrete outputs: cost_year
         self.add_discrete_output(
             "cost_year", val=self.config.cost_year, desc="Dollar year for costs"
-        )
-
-        # Marginal cost output for dispatch decisions
-        model_inputs = self.options["tech_config"].get("model_inputs", {})
-        shared = model_inputs.get("shared_parameters", {})
-        commodity_rate_units = shared.get("commodity_rate_units", "kW")
-        self.add_output(
-            "marginal_cost",
-            val=self.config.marginal_cost,
-            units=f"USD/({commodity_rate_units}*h)",
-            desc="Marginal cost of production for dispatch decisions",
         )
 
         # dt is seconds per timestep

--- a/h2integrate/demand/demand_base.py
+++ b/h2integrate/demand/demand_base.py
@@ -44,6 +44,7 @@ class DemandComponentBase(PerformanceModelBaseClass):
     """
 
     _time_step_bounds = (3600, 3600)  # (min, max) time step lengths compatible with this model
+    _control_classifier = "dispatchable"
 
     def setup(self):
         """Define inputs and outputs for demand component.


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELETE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code highlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Refactor marginal cost: move from CostModelBaseClass to SLC `cost_per_tech` config
<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
Replaces the `marginal_cost` field on `CostModelBaseConfig`/`CostModelBaseClass` with a new `cost_per_tech` config in `plant_config["system_level_control"]`. This decouples dispatch cost weights from the finance model and gives users four ways to specify marginal cost per dispatchable technology:

1. **Scalar** — a numeric constant (e.g. `0.05` for $0.05/kWh)
2. **`buy_price`** — uses the technology's purchase price (scalar or time-varying), e.g. Grid's `electricity_buy_price`
3. **`VarOpEx`** — derives marginal cost from the tech's own `VarOpEx / annual_production`
4. **`feedstock`** — sums `VarOpEx` from all upstream feedstock technologies (found via `technology_interconnections`) and divides by the tech's production

```yaml
# Example plant_config usage
system_level_control:
  control_strategy: ProfitMaximizationControl
  cost_per_tech:
    natural_gas_plant: feedstock  # uses ng_feedstock's VarOpEx
    grid_buy: buy_price           # uses electricity_buy_price
    some_gen: 0.05                # fixed $/kWh weight
    converter: VarOpEx            # uses own VarOpEx output
```

## Section 1: Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [x] Feature Enhancement
  - [x] Framework
  - [ ] New Model
  - [x] Updated Model
  - [ ] Tools/Utilities
  - [ ] Other (please describe):
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## Section 2: Draft PR Checklist
<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
<!--Complete when opening a draft PR. -->
- [x] Open draft PR
- [x] Describe the feature that will be added
- [x] Fill out TODO list steps
- [x] Describe requested feedback from reviewers on draft PR
- [ ] Complete Section 7: New Model Checklist (if applicable)
<!-- Describe the feature in this PR and outline next steps -->
### TODO:
- [x] Remove `marginal_cost` from `CostModelBaseConfig` and `CostModelBaseClass`
- [x] Remove `marginal_cost` output from `GenericConverterCostModel`
- [x] Add `_setup_marginal_costs()`, `_compute_marginal_costs()`, and per-mode helpers to `SystemLevelControlBase`
- [x] Update `ProfitMaximizationControl` and `CostMinimizationControl` to use new approach
- [x] Update `add_system_level_controller()` connection logic in `H2IntegrateModel`
- [x] Update example configs and run scripts
- [x] Add tests for all four modes (scalar, buy_price, VarOpEx, feedstock)

### Type of Reviewer Feedback Requested (on Draft PR)
<!-- Outline the feedback that would be helpful from reviewers while it's a draft PR -->
**Structural feedback**: Is the name `cost_per_tech` good? Is there a better or more clear name?

**Implementation feedback**: Review the feedstock discovery logic (`_find_feedstock_techs`) and whether the VarOpEx-to-marginal-cost conversion is correct.

**Other feedback**: Are there additional cost modes we should support?

