### PR TITLE
Azimuth angle warnings and defaults in PySAM solar model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 - Added capability to specify demand technology for system-level control, and renamed the framework-derived system-level control classification dict from `slc_config` to `slc_topology` to distinguish it from the user-authored `control_parameters` block. [PR 784](https://github.com/NatLabRockies/H2Integrate/pull/784)
 - Add support for slice notation in technology connections to allow users to connect between variables of different shapes. [PR 774](https://github.com/NatLabRockies/H2Integrate/pull/774)
 - Updated `commodity_sell_price` input to `ProFastNPV` to be per year of the plant life. Also updated `BasicProFASTParameterConfig.as_dict()` so explicitly input escalation values are not overwritten to the general inflation rate [PR 799](https://github.com/NatLabRockies/H2Integrate/pull/799)
-
+- Added `calc_azimuth_angle()` to `PYSAMSolarPlantPerformanceModel` to provide default azimuth angle based on whether the site is in the northern or southern hemisphere [PR 806](https://github.com/NatLabRockies/H2Integrate/pull/806)
 
 ## 0.8 [April 15, 2026]
 

--- a/h2integrate/converters/solar/solar_pysam.py
+++ b/h2integrate/converters/solar/solar_pysam.py
@@ -1,3 +1,6 @@
+import warnings
+
+import numpy as np
 import PySAM.Pvwattsv8 as Pvwatts
 from attrs import field, define
 
@@ -230,6 +233,38 @@ class PYSAMSolarPlantPerformanceModel(SolarPerformanceBaseClass):
             # For latitudes > 50, use latitude directly
             return abs_latitude
 
+    def calc_azimith_angle(self, latitude):
+        if (
+            azimuth := self.design_config.pysam_options.get("SystemDesign", {}).get("azimuth", None)
+        ) is not None:
+            # User did explicitly define azimuth angle
+            if latitude < 0.0 and float(azimuth) == 180.0:
+                # Southern hemisphere with south-facing azimuth angle
+                msg = (
+                    f"Site is located in southern hemisphere (latitude of {latitude}) "
+                    f"and solar-PV azimuth angle is set to {azimuth} degrees. For sites in the "
+                    "southern hemisphere, it is recommended to use an north-facing azimuth angle "
+                    "of 0 degrees. Solar-PV generation may be lower than expected. "
+                )
+                warnings.warn(msg, UserWarning, stacklevel=3)
+            if latitude > 0.0 and float(np.abs(azimuth)) == 0.0:
+                # Northern hemisphere with north-facing azimuth angle
+                msg = (
+                    f"Site is located in northern hemisphere (latitude of {latitude}) "
+                    f"and solar-PV azimuth angle is set to {azimuth} degrees. For sites in the "
+                    "northern hemisphere, it is recommended to use an south-facing azimuth angle "
+                    "of 180 degrees. Solar-PV generation may be lower than expected. "
+                )
+                warnings.warn(msg, UserWarning, stacklevel=3)
+
+            return azimuth
+
+        # User did not explicitly define azimuth angle
+        if latitude < 0.0:
+            # North-facing for southern-hemisphere
+            return 0.0
+        return 180.0  # South-facing for northern hemisphere
+
     def format_resource_data(self, solar_resource_data):
         """Format solar resource data into the format required for the
         PySAM PvWattsv8 module. This method includes:
@@ -285,6 +320,11 @@ class PYSAMSolarPlantPerformanceModel(SolarPerformanceBaseClass):
         tilt_angle = self.design_dict.get("SystemDesign", {}).get("tilt", tilt)
         # assign the tilt angle
         self.system_model.value("tilt", tilt_angle)
+
+        # calculate the azimuth angle based on site latitude or get user input azimuth angle
+        azimuth = self.calc_azimith_angle(discrete_inputs["solar_resource_data"].get("site_lat", 0))
+        # assign the azimuth angle
+        self.system_model.value("azimuth", azimuth)
 
         # set the system capacity
         self.system_model.value("system_capacity", inputs["system_capacity_DC"][0])

--- a/h2integrate/converters/solar/solar_pysam.py
+++ b/h2integrate/converters/solar/solar_pysam.py
@@ -233,7 +233,24 @@ class PYSAMSolarPlantPerformanceModel(SolarPerformanceBaseClass):
             # For latitudes > 50, use latitude directly
             return abs_latitude
 
-    def calc_azimith_angle(self, latitude):
+    def calc_azimuth_angle(self, latitude):
+        """
+        Calculates the azimuth angle of the PV panel based on the site latitude and user inputs.
+        If a user specifies the azimuth angle in `design_config.pysam_options.SystemDesign.azimuth`,
+        that value will be returned. If the user-specified azimuth angle seems incorrect based on
+        the site latitude, a UserWarning will be raised. If the user does not specify the azimuth
+        angle explicitly, then the azimuth angle will be returned as:
+
+        - 180 degrees (south-facing) if the site is in the northern hemisphere (latitude>=0)
+        - 0 degrees (north-facing) if the site is in the southern hemisphere (latitude<0)
+
+        Args:
+            latitude (float): latitude of the site in degrees.
+
+        Returns:
+            float: azimuth angle of the solar panels in degrees.
+        """
+
         if (
             azimuth := self.design_config.pysam_options.get("SystemDesign", {}).get("azimuth", None)
         ) is not None:
@@ -322,7 +339,7 @@ class PYSAMSolarPlantPerformanceModel(SolarPerformanceBaseClass):
         self.system_model.value("tilt", tilt_angle)
 
         # calculate the azimuth angle based on site latitude or get user input azimuth angle
-        azimuth = self.calc_azimith_angle(discrete_inputs["solar_resource_data"].get("site_lat", 0))
+        azimuth = self.calc_azimuth_angle(discrete_inputs["solar_resource_data"].get("site_lat", 0))
         # assign the azimuth angle
         self.system_model.value("azimuth", azimuth)
 

--- a/h2integrate/converters/solar/solar_pysam.py
+++ b/h2integrate/converters/solar/solar_pysam.py
@@ -260,7 +260,7 @@ class PYSAMSolarPlantPerformanceModel(SolarPerformanceBaseClass):
             return azimuth
 
         # User did not explicitly define azimuth angle
-        if latitude < 0.0:
+        if latitude <= 0.0:
             # North-facing for southern-hemisphere
             return 0.0
         return 180.0  # South-facing for northern hemisphere

--- a/h2integrate/converters/solar/test/test_pysam_solar.py
+++ b/h2integrate/converters/solar/test/test_pysam_solar.py
@@ -143,26 +143,26 @@ class TestCalcAzimuthAngle:
     )
     def test_azimuth_angle(self, latitude, user_input_azimuth, expected_azimuth):
         model = self._make_model(azimuth=user_input_azimuth)
-        result = PYSAMSolarPlantPerformanceModel.calc_azimith_angle(model, latitude)
+        result = PYSAMSolarPlantPerformanceModel.calc_azimuth_angle(model, latitude)
         assert result == pytest.approx(expected_azimuth)
 
     def test_southern_hemisphere_azimuth_warning(self):
         latitude = -30.0  # southern hemisphere
-        user_input_azimuth = 180.0  # south-facing
+        user_input_azimuth = 180  # south-facing
         model = self._make_model(azimuth=user_input_azimuth)
 
         expected_str = f"Site is located in southern hemisphere (latitude of {latitude})"
         with pytest.warns(UserWarning) as excinfo:
-            PYSAMSolarPlantPerformanceModel.calc_azimith_angle(model, latitude)
+            PYSAMSolarPlantPerformanceModel.calc_azimuth_angle(model, latitude)
         assert expected_str in str(excinfo.list[0].message)
 
     def test_northern_hemisphere_azimuth_warning(self):
         latitude = 30.0  # northern hemisphere
-        user_input_azimuth = 0.0  # north-facing
+        user_input_azimuth = 0  # north-facing
         model = self._make_model(azimuth=user_input_azimuth)
         expected_str = f"Site is located in northern hemisphere (latitude of {latitude})"
         with pytest.warns(UserWarning) as excinfo:
-            PYSAMSolarPlantPerformanceModel.calc_azimith_angle(model, latitude)
+            PYSAMSolarPlantPerformanceModel.calc_azimuth_angle(model, latitude)
         assert expected_str in str(excinfo.list[0].message)
 
 

--- a/h2integrate/converters/solar/test/test_pysam_solar.py
+++ b/h2integrate/converters/solar/test/test_pysam_solar.py
@@ -109,6 +109,63 @@ class TestCalcTiltAngle:
         assert result == pytest.approx(0)  # default fallback
 
 
+@pytest.mark.unit
+class TestCalcAzimuthAngle:
+    """Unit tests for PYSAMSolarPlantPerformanceModel.calc_tilt_angle
+    with various latitudes including southern hemisphere (negative) values.
+    """
+
+    def _make_model(self, azimuth: float | None = None):
+        """Create a lightweight mock of PYSAMSolarPlantPerformanceModel
+        with the minimum attributes needed by calc_tilt_angle."""
+        model = MagicMock(spec=PYSAMSolarPlantPerformanceModel)
+        model.design_config = MagicMock()
+        model.design_config.tilt_angle_func = "none"
+        model.design_config.tilt = 0.0
+        model.design_config.create_model_from = "default"
+        if azimuth is not None:
+            model.design_config.pysam_options = {"SystemDesign": {"azimuth": azimuth}}
+        else:
+            model.design_config.pysam_options = {}
+        model.system_model = MagicMock()
+        model.system_model.value.return_value = 20.0  # default tilt from PySAM model
+        return model
+
+    # --- tilt_angle_func = "lat" ---
+    @pytest.mark.parametrize(
+        "latitude, user_input_azimuth, expected_azimuth",
+        [
+            (30.0, None, 180.0),
+            (-30.0, None, 0.0),
+            (30.0, 90.0, 90.0),
+            (-30.0, 90.0, 90.0),
+        ],
+    )
+    def test_azimuth_angle(self, latitude, user_input_azimuth, expected_azimuth):
+        model = self._make_model(azimuth=user_input_azimuth)
+        result = PYSAMSolarPlantPerformanceModel.calc_azimith_angle(model, latitude)
+        assert result == pytest.approx(expected_azimuth)
+
+    def test_southern_hemisphere_azimuth_warning(self):
+        latitude = -30.0  # southern hemisphere
+        user_input_azimuth = 180.0  # south-facing
+        model = self._make_model(azimuth=user_input_azimuth)
+
+        expected_str = f"Site is located in southern hemisphere (latitude of {latitude})"
+        with pytest.warns(UserWarning) as excinfo:
+            PYSAMSolarPlantPerformanceModel.calc_azimith_angle(model, latitude)
+        assert expected_str in str(excinfo.list[0].message)
+
+    def test_northern_hemisphere_azimuth_warning(self):
+        latitude = 30.0  # northern hemisphere
+        user_input_azimuth = 0.0  # north-facing
+        model = self._make_model(azimuth=user_input_azimuth)
+        expected_str = f"Site is located in northern hemisphere (latitude of {latitude})"
+        with pytest.warns(UserWarning) as excinfo:
+            PYSAMSolarPlantPerformanceModel.calc_azimith_angle(model, latitude)
+        assert expected_str in str(excinfo.list[0].message)
+
+
 @fixture
 def basic_pysam_options():
     pysam_options = {

--- a/h2integrate/resource/solar/test/test_pvwatts_integration.py
+++ b/h2integrate/resource/solar/test/test_pvwatts_integration.py
@@ -11,7 +11,7 @@ def pysam_performance_model():
     pysam_options = {
         "SystemDesign": {
             "array_type": 2,
-            "azimuth": 180,
+            # "azimuth": 180,
             "bifaciality": 0.65,
             "inv_eff": 96.0,
             "losses": 14.0757,

--- a/h2integrate/resource/solar/test/test_pvwatts_integration.py
+++ b/h2integrate/resource/solar/test/test_pvwatts_integration.py
@@ -11,7 +11,6 @@ def pysam_performance_model():
     pysam_options = {
         "SystemDesign": {
             "array_type": 2,
-            # "azimuth": 180,
             "bifaciality": 0.65,
             "inv_eff": 96.0,
             "losses": 14.0757,


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELETE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code highlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Azimuth angle warnings and defaults in PySAM solar model
<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
Added a new function called `calc_azimith_angle()` to `PYSAMSolarPlantPerformanceModel`. This function is intended to adjust default design parameters for southern-hemisphere sites. In the PVWatts models, the azimuth angle will default to 180 degrees (south-facing) if the user does not specify it in the `pysam_options` dictionary. This default is not great for sites in the southern hemisphere, where the solar panels should be facing north. This new method has the following logic:
- If the user **does not** specify azimuth angle in `pysam_options`:
   - if latitude>0.0 (northern hemisphere), return azimuth angle of 180 degrees (south facing)
   - if latitude<0.0 (souther hemisphere), return azimuth angle of 0 degrees (north facing)
- If the user **does** specify azimuth angle in `pysam_options`:
   - raise a user warning if latitude>0.0 and azimuth is set to 0.0
   - raise a user warning if latitude<0.0 and azimuth is set to 180.0
   - return the user input azimuth angle

## Section 1: Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [ ] Feature Enhancement
  - [ ] Framework
  - [ ] New Model
  - [x] Updated Model
  - [ ] Tools/Utilities
  - [ ] Other (please describe):
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## Section 2: Draft PR Checklist
<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
<!--Complete when opening a draft PR. -->
- [x] Open draft PR
- [x] Describe the feature that will be added
- [x] Fill out TODO list steps
- [x] Describe requested feedback from reviewers on draft PR
- [ ] Complete Section 7: New Model Checklist (if applicable)
<!-- Describe the feature in this PR and outline next steps -->

### TODO:
- [x] Add regression/integration test for site in the southern hemisphere (somewhat taken care of with change to `h2integrate/resource/solar/test/test_pvwatts_integration.py`)
- [x] Add doc-string to `calc_azimuth_angle()` method

### Type of Reviewer Feedback Requested (on Draft PR)
<!-- Outline the feedback that would be helpful from reviewers while it's a draft PR -->
**Structural feedback**:

**Implementation feedback**:

**Other feedback**:

## Section 3: General PR Checklist
<!--Complete when converting draft PR to a merge-ready PR. -->
- [x] PR description thoroughly describes the new feature, bug fix, etc.
- [x] Added tests for new functionality or bug fixes
- [x] Tests pass (If not, and this is expected, please elaborate in the Section 6: Test Results)
- [x] Documentation
  - [x] Docstrings are up-to-date
  - [x] Related `docs/` files are up-to-date, or added when necessary
  - [x] Documentation has been rebuilt successfully
  - [x] Examples have been updated (if applicable)
- [x] `CHANGELOG.md`
  - [x] At least one complete sentence has been provided to describe the changes made in this PR
  - [x] After the above, a hyperlink has been provided to the PR using the following format:
    "A complete thought. [PR XYZ]((https://github.com/NatLabRockies/H2Integrate/pull/XYZ)", where
    `XYZ` should be replaced with the actual number.

## Section 4: Related Issues
<!--If this PR relates to an existing GitHub issue, please link the issue and indicate whether this PR would fully or partially resolve that issue. Please also link any issues that were created due to this PR-->


## Section 5: Impacted Areas of the Software
<!--
Replace the below example with any added or modified files, and briefly describe what has been changed or added, and why. Can exclude CHANGELOG.md, doc pages and supported_models.py.
-->
### Section 5.1: New Files
N/A

### Section 5.2: Modified Files
- `PYSAMSolarPlantPerformanceModel` in `h2integrate/converters/solar/solar_pysam.py`
  - `calc_azimuth_angle()`: new method that warns user if azimuth angle is set to a "bad" default and returns the azimuth angle (either user-set or default value based on latitude)
  - `compute()`: added call to `calc_azimuth_angle`
- `h2integrate/converters/solar/test/test_pysam_solar.py`
   - `TestCalcAzimuthAngle`: unit tests for `calc_azimuth_angle` method
## Section 6: Additional Supporting Information
<!--Add any other context about the problem here.-->


## Section 7: Test Results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->

I removed the `azimuth` input of the `pysam_options` dictionary in `h2integrate/resource/solar/test/test_pvwatts_integration.py`. I expected that the subtests for the AEP would fail for sites in the southern hemisphere (tests for `Himawari7SolarAPI`, `HimawariTMYSolarAPI`, `MeteosatPrimeMeridianTMYSolarAPI`, and `OpenMeteoHistoricalSolarResource-LeapYear`). These tests did not fail (unexpected), I dug into the `Himawari7SolarAPI` case to see why. Basically, the AEP did change a little but it was below the testing tolerance. 
- `Himawari7SolarAPI`:
   - AEP with azimuth angle of 0.0: 473577280.8123779 kWh/year
   - AEP with azimuth angle of 180.0:  473577280.26918286 kWh/year
   - AEP increased by 0.5431950688362122 kWh with azimuth of 0.0 instead of 180.0
   - Change in AEP is below the test tolerance so the tests don't change





<!--
__ For NLR use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NatLabRockies/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
