### PR TITLE
Correct pipe rate units from galUS to galUS/h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - Add support for slice notation in technology connections to allow users to connect between variables of different shapes. [PR 774](https://github.com/NatLabRockies/H2Integrate/pull/774)
 - Updated `commodity_sell_price` input to `ProFastNPV` to be per year of the plant life. Also updated `BasicProFASTParameterConfig.as_dict()` so explicitly input escalation values are not overwritten to the general inflation rate [PR 799](https://github.com/NatLabRockies/H2Integrate/pull/799)
 - Added `calc_azimuth_angle()` to `PYSAMSolarPlantPerformanceModel` to provide default azimuth angle based on whether the site is in the northern or southern hemisphere [PR 806](https://github.com/NatLabRockies/H2Integrate/pull/806)
+- Corrected water rate units in pipe feedstock from galUS to galUS/h [PR 813](https://github.com/NatLabRockies/H2Integrate/pull/813)
 
 ## 0.8 [April 15, 2026]
 

--- a/examples/21_iron_examples/iron_dri/tech_config.yaml
+++ b/examples/21_iron_examples/iron_dri/tech_config.yaml
@@ -109,7 +109,7 @@ technologies:
     model_inputs:
       shared_parameters:
         commodity: water
-        commodity_rate_units: galUS  # galUS/h
+        commodity_rate_units: galUS/h
       performance_parameters:
         rated_capacity: 40000.  # need 38710.49649 galUS/h
       cost_parameters:
@@ -200,7 +200,7 @@ technologies:
     model_inputs:
       shared_parameters:
         commodity: water
-        commodity_rate_units: galUS  # galUS/h
+        commodity_rate_units: galUS/h
       performance_parameters:
         rated_capacity: 10000.  # need 9083.687924154146 galUS/h
       cost_parameters:

--- a/examples/21_iron_examples/iron_mapping/tech_config.yaml
+++ b/examples/21_iron_examples/iron_mapping/tech_config.yaml
@@ -109,7 +109,7 @@ technologies:
     model_inputs:
       shared_parameters:
         commodity: water
-        commodity_rate_units: galUS  # galUS/h
+        commodity_rate_units: galUS/h
       performance_parameters:
         rated_capacity: 40000.  # need 38710.49649 galUS/h
       cost_parameters:

--- a/h2integrate/converters/iron/iron_dri_plant.py
+++ b/h2integrate/converters/iron/iron_dri_plant.py
@@ -66,7 +66,7 @@ class HydrogenIronReductionPlantPerformanceComponent(IronReductionPlantBasePerfo
         self.product = "h2_dri"
         self.feedstocks_to_units = {
             "natural_gas": "MMBtu/h",
-            "water": "galUS",  # "galUS/h"
+            "water": "galUS/h",
             "iron_ore": "t/h",
             "electricity": "kW",
             "hydrogen": "t/h",
@@ -93,7 +93,7 @@ class NaturalGasIronReductionPlantPerformanceComponent(IronReductionPlantBasePer
     def setup(self):
         self.feedstocks_to_units = {
             "natural_gas": "MMBtu/h",
-            "water": "galUS",  # "galUS/h"
+            "water": "galUS/h",
             "iron_ore": "t/h",
             "electricity": "kW",
             "reformer_catalyst": "(m**3)",  # "(m**3)/h"

--- a/h2integrate/converters/iron/test/test_rosner_dri.py
+++ b/h2integrate/converters/iron/test/test_rosner_dri.py
@@ -47,7 +47,7 @@ def ng_feedstock_availability_costs():
         },
         "water": {
             "rated_capacity": 40000.0,  # need 38071.049649 galUS/h
-            "units": "galUS",
+            "units": "galUS/h",
             "price": 1670.0,  # cost is $0.441167535/t, equal to $1670.0004398318847/galUS
         },
         "iron_ore": {
@@ -80,7 +80,7 @@ def h2_feedstock_availability_costs():
         },
         "water": {
             "rated_capacity": 24000.0,  # need 23066.4878077501 galUS/h
-            "units": "galUS",
+            "units": "galUS/h",
             "price": 1670.0,  # TODO: update cost is $0.441167535/t, equal to $1670.0004398318847/galUS
         },
         "iron_ore": {

--- a/h2integrate/converters/steel/steel_eaf_plant.py
+++ b/h2integrate/converters/steel/steel_eaf_plant.py
@@ -63,7 +63,7 @@ class HydrogenEAFPlantPerformanceComponent(ElectricArcFurnacePlantBasePerformanc
         self.product = "h2_eaf"
         self.feedstocks_to_units = {
             "natural_gas": "MMBtu/h",
-            "water": "galUS",  # "galUS/h"
+            "water": "galUS/h",
             "carbon": "t/h",
             "lime": "t/h",
             "sponge_iron": "t/h",
@@ -90,7 +90,7 @@ class NaturalGasEAFPlantPerformanceComponent(ElectricArcFurnacePlantBasePerforma
     def setup(self):
         self.feedstocks_to_units = {
             "natural_gas": "MMBtu/h",
-            "water": "galUS",  # "galUS/h"
+            "water": "galUS/h",
             "sponge_iron": "t/h",
             "electricity": "kW",
         }

--- a/h2integrate/converters/steel/test/test_rosner_eaf.py
+++ b/h2integrate/converters/steel/test/test_rosner_eaf.py
@@ -62,7 +62,7 @@ def ng_feedstock_availability_costs():
         },
         "water": {
             "rated_capacity": 10000.0,  # need 9082.97025163801 galUS/h
-            "units": "galUS",
+            "units": "galUS/h",
             "price": 1670.0,  # cost is $0.441167535/t, equal to $1670.0004398318847/galUS
         },
         "sponge_iron": {
@@ -100,7 +100,7 @@ def h2_feedstock_availability_costs():
         },
         "water": {
             "rated_capacity": 6000.0,  # need 5766.528266260271 galUS/h
-            "units": "galUS",
+            "units": "galUS/h",
             "price": 1670.0,  # TODO: update cost is $0.441167535/t, equal to $1670.0004398318847/galUS
         },
         "sponge_iron": {

--- a/h2integrate/feedstocks/test/test_feedstocks.py
+++ b/h2integrate/feedstocks/test/test_feedstocks.py
@@ -325,13 +325,13 @@ def test_multiple_different_type_feedstocks(plant_config):
     )
 
     # Electricity feedstock
-    ec_units = "MW*h"
+    ec_units = "MW"
     elec_config, _ = create_basic_feedstock_config(
         feedstock_type="electricity", units=ec_units, rated_capacity=50.0, price=0.05
     )
 
     # Water feedstock
-    h2o_units = "galUS"
+    h2o_units = "galUS/h"
     water_config, _ = create_basic_feedstock_config(
         feedstock_type="water", units=h2o_units, rated_capacity=1000.0, price=0.001
     )

--- a/h2integrate/transporters/pipe.py
+++ b/h2integrate/transporters/pipe.py
@@ -38,7 +38,7 @@ class PipePerformanceModel(om.ExplicitComponent):
         if transport_item == "natural_gas":
             units = "MMBtu/h"
         elif transport_item == "water":
-            units = "galUS"
+            units = "galUS/h"
         elif transport_item == "co2":
             units = "kg/h"
         else:


### PR DESCRIPTION
<!--
IMPORTANT NOTES

1. Use GH flavored markdown when writing your description:
   https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

2. If all boxes in the PR Checklist cannot be checked, this PR should be marked as a draft.

3. DO NOT DELETE ANYTHING FROM THIS TEMPLATE. If a section does not apply to you, simply write
   "N/A" in the description.

4. Code snippets to highlight new, modified, or problematic functionality are highly encouraged,
   though not required. Be sure to use proper code highlighting as demonstrated below.

   ```python
    def a_func():
        return 1

    a = 1
    b = a_func()
    print(a + b)
    ```
-->

<!--The title should clearly define your contribution succinctly.-->
# Correct pipe rate units from galUS to galUS/h
<!-- Describe your feature here. Please include any code snippets or examples in this section. -->
The pipe transporter specified units of galUS for the rate units of water, which was then propagated into the iron work. This PR corrects rate units from galUS to galUS/h where appropriate.

## Section 1: Type of Contribution
<!-- Check all that apply to help reviewers understand your contribution -->
- [ ] Feature Enhancement
  - [ ] Framework
  - [ ] New Model
  - [ ] Updated Model
  - [ ] Tools/Utilities
  - [ ] Other (please describe):
- [x] Bug Fix
- [ ] Documentation Update
- [ ] CI Changes
- [ ] Other (please describe):

## Section 2: Draft PR Checklist
<!--Tick these boxes if they are complete, or format them as "[x]" for the markdown to render. -->
<!--Complete when opening a draft PR. -->
- [ ] Open draft PR
- [ ] Describe the feature that will be added
- [ ] Fill out TODO list steps
- [ ] Describe requested feedback from reviewers on draft PR
- [ ] Complete Section 7: New Model Checklist (if applicable)
<!-- Describe the feature in this PR and outline next steps -->
### TODO:
- [ ] Step 1
- [ ] Step 2

### Type of Reviewer Feedback Requested (on Draft PR)
<!-- Outline the feedback that would be helpful from reviewers while it's a draft PR -->
**Structural feedback**:

**Implementation feedback**:

**Other feedback**:

## Section 3: General PR Checklist
<!--Complete when converting draft PR to a merge-ready PR. -->
- [x] PR description thoroughly describes the new feature, bug fix, etc.
- [-] Added tests for new functionality or bug fixes
- [x] Tests pass (If not, and this is expected, please elaborate in the Section 6: Test Results)
- [x] Documentation
  - [-] Docstrings are up-to-date
  - [-] Related `docs/` files are up-to-date, or added when necessary
  - [-] Documentation has been rebuilt successfully
  - [x] Examples have been updated (if applicable)
- [x] `CHANGELOG.md`
  - [x] At least one complete sentence has been provided to describe the changes made in this PR
  - [x] After the above, a hyperlink has been provided to the PR using the following format:
    "A complete thought. [PR XYZ]((https://github.com/NatLabRockies/H2Integrate/pull/XYZ)", where
    `XYZ` should be replaced with the actual number.

## Section 4: Related Issues
<!--If this PR relates to an existing GitHub issue, please link the issue and indicate whether this PR would fully or partially resolve that issue. Please also link any issues that were created due to this PR-->
Somewhat related to #223 

## Section 5: Impacted Areas of the Software
### Section 5.1: New Files
- None

### Section 5.2: Modified Files
- examples/21_iron_examples/iron_dri/tech_config.yaml
  commodity_rate_units (technologies entries): Updated water commodity rate units from galUS to galUS/h to represent a flow rate consistently with hourly usage assumptions.

- examples/21_iron_examples/iron_mapping/tech_config.yaml
  commodity_rate_units (technologies entry): Updated water commodity rate units from galUS to galUS/h for consistency with rate-based feedstock accounting.

- h2integrate/converters/iron/iron_dri_plant.py
  HydrogenIronReductionPlantPerformanceComponent ([line 69](h2integrate/converters/iron/iron_dri_plant.py#L69)): Changed water units mapping to galUS/h so internal unit metadata matches hourly commodity rates.
  NaturalGasIronReductionPlantPerformanceComponent ([line 96](h2integrate/converters/iron/iron_dri_plant.py#L96)): Changed water units mapping to galUS/h for parity with the hydrogen pathway and downstream unit checks.

- h2integrate/converters/iron/test/test_rosner_dri.py
  ng_feedstock_availability_costs ([line 50](h2integrate/converters/iron/test/test_rosner_dri.py#L50)): Updated expected water units from galUS to galUS/h to match converter unit definitions.
  h2_feedstock_availability_costs ([line 83](h2integrate/converters/iron/test/test_rosner_dri.py#L83)): Updated expected water units from galUS to galUS/h to keep hydrogen-case assertions aligned.

- h2integrate/converters/steel/steel_eaf_plant.py
  HydrogenEAFPlantPerformanceComponent ([line 66](h2integrate/converters/steel/steel_eaf_plant.py#L66)): Changed water units mapping to galUS/h to use hourly flow units.
  NaturalGasEAFPlantPerformanceComponent ([line 93](h2integrate/converters/steel/steel_eaf_plant.py#L93)): Changed water units mapping to galUS/h for consistent EAF feedstock-rate treatment.

- h2integrate/converters/steel/test/test_rosner_eaf.py
  ng_feedstock_availability_costs ([line 65](h2integrate/converters/steel/test/test_rosner_eaf.py#L65)): Updated expected water units to galUS/h so test expectations match EAF model output metadata.
  h2_feedstock_availability_costs ([line 103](h2integrate/converters/steel/test/test_rosner_eaf.py#L103)): Updated expected water units to galUS/h for hydrogen EAF case consistency.

- h2integrate/feedstocks/test/test_feedstocks.py
  test_multiple_different_type_feedstocks ([line 328](h2integrate/feedstocks/test/test_feedstocks.py#L328)): Corrected electricity units expectation from MW*h to MW to align with rate-based input conventions.
  test_multiple_different_type_feedstocks ([line 334](h2integrate/feedstocks/test/test_feedstocks.py#L334)): Updated water units expectation from galUS to galUS/h to align with hourly water consumption rates.

- h2integrate/transporters/pipe.py
  PipePerformanceModel unit selection ([line 41](h2integrate/transporters/pipe.py#L41)): Changed water commodity units from galUS to galUS/h.

## Section 6: Additional Supporting Information
<!--Add any other context about the problem here.-->


## Section 7: Test Results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any
failing test cases.
-->

## Section 8 (Optional): New Model Checklist
<!-- Complete this section only if you checked "New Model" above -->
- [ ] **Model Structure**:
  - [ ] Follows established naming conventions outlined in `docs/developer_guide/coding_guidelines.md`
  - [ ] Used `attrs` class to define the `Config` to load in attributes for the model
    - [ ] If applicable: inherit from `BaseConfig` or `CostModelBaseConfig`
  - [ ] Added: `initialize()` method, `setup()` method, `compute()` method
    - [ ] If applicable: inherit from `CostModelBaseClass`
- [ ] **Integration**: Model has been properly integrated into H2Integrate
  - [ ] Added to `supported_models.py`
  - [ ] If a new commodity_type is added, update `create_financial_model` in `h2integrate_model.py`
- [ ] **Tests**: Unit tests have been added for the new model
  - [ ] [Pytest-style unit tests](https://realpython.com/pytest-python-testing/)
  - [ ] Unit tests are in a "test" folder within the folder a new model was added to
  - [ ] If applicable add integration tests
- [ ] **Example**: If applicable, a working example demonstrating the new model has been created
  - [ ] Input file comments
  - [ ] Run file comments
  - [ ] Example has been tested and runs successfully in `test_all_examples.py`
- [ ] **Documentation**:
  - [ ] Write docstrings using the [Google style](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
  - [ ] Model added to the main models list in `docs/user_guide/model_overview.md`
    - [ ] Model documentation page added to the appropriate `docs/` section
    - [ ] `<model_name>.md` is added to the `_toc.yml`
  - [ ] Run `generate_class_hierarchy.py` to update the class hierarchy diagram in `docs/developer_guide/class_structure.md`





<!--
__ For NLR use __
Release checklist:
- [ ] Update the version in h2integrate/__init__.py
- [ ] Verify docs builds correctly
- [ ] Create a tag on the main branch in the NatLabRockies/H2Integrate repository and push
- [ ] Ensure the Test PyPI build is successful
- [ ] Create a release on the main branch
-->
